### PR TITLE
[docs] Add database initial schema

### DIFF
--- a/docs/database-schema.dbml
+++ b/docs/database-schema.dbml
@@ -54,12 +54,32 @@ Table homologues {
 }
 
 Table pdb {
-  Proteinaccession_NCBI varchar //This is the filename
+  Proteinaccession_NCBI varchar //This is the filename (Removing the ".1" in the example)
   Location varchar // I am guessing we will store these files somewhere
 }
+
+Table fasta_nucleotide {
+  Proteinaccession_NCBI varchar // This is the ID to find the sequence in the fasta file
+  Sequence varchar // Will we store the sequence for each ID in the database?
+}
+
+Table fasta_protein {
+  Proteinaccession_NCBI varchar // This is the ID to find the sequence in the fasta file
+  Sequence varchar // Will we store the sequence for each ID in the database?
+}
+
+Ref experimental: fasta_protein.Proteinaccession_NCBI < experimental.Proteinaccession_NCBI
+
+Ref experimental: fasta_nucleotide.Proteinaccession_NCBI < experimental.Proteinaccession_NCBI
+
+Ref experimental: pdb.Proteinaccession_NCBI < experimental.Proteinaccession_NCBI
+
+Ref experimental: homologues.query < experimental.Proteinaccession_NCBI // This is not exactly the same id (Removing the ".1" in the example)
 
 Ref experimental: experimental.Compound < compounds.Biocide_name
 
 Ref homologues: homologues.target < groups.Matching_IDs
 
-Ref experimental: pdb.Proteinaccession_NCBI < experimental.Proteinaccession_NCBI
+// 2. Groups file
+//- What are the Matching_ids in the groups files? Are they used for something? (foreign key?)
+//- The second part of the Unique ID seems to be the same as the NCBI ID in the homologues.query and Experimental.Proteinaccession_NCBI

--- a/docs/database-schema.dbml
+++ b/docs/database-schema.dbml
@@ -1,0 +1,65 @@
+// Use DBML to define your database structure
+// Docs: https://dbml.dbdiagram.io/docs
+
+Table compounds {
+  Biocide_name varchar
+  CAS_Number varchar
+  Chemical_class varchar
+}
+
+Table experimental {
+  BacMet_ID varchar
+  Gene_name varchar
+  Code_For varchar
+  Family varchar
+  Proteinaccession_NCBI varchar //Could be foreign key?
+  Nucleotide_accession_ENA_EMBL varchar //Could be foreign key?
+  Protein_accession_Uniprot varchar //Could be foreign key?
+  Organism varchar //Could be foreign key?
+  Location varchar //Could be foreign key?
+  Type_of_compounds	varchar //Could be foreign key?
+  Compound varchar // Foreign key to compounds table
+  Description varchar
+  Length_aa	varchar
+  Reference varchar
+  Number_of_homologues int
+}
+
+Table groups {
+  Unique_ID varchar //The second part seems to be the Proteinaccession_NCBI
+  Sequence varchar
+  Matching_IDs varchar //This is definitely not a varchar
+
+}
+
+Table homologues {
+  query varchar
+  target varchar
+  fident float
+  alnlen int
+  mismatch int
+  gapopen int
+  qstart int
+  qend int
+  qlen int
+  tstart int
+  tend int
+  tlen int
+  evalue int //Very big number
+  bits int
+  prob int
+  lddt float
+  alntmscore float
+  rmsd float
+}
+
+Table pdb {
+  Proteinaccession_NCBI varchar //This is the filename
+  Location varchar // I am guessing we will store these files somewhere
+}
+
+Ref experimental: experimental.Compound < compounds.Biocide_name
+
+Ref homologues: homologues.target < groups.Matching_IDs
+
+Ref experimental: pdb.Proteinaccession_NCBI < experimental.Proteinaccession_NCBI


### PR DESCRIPTION
The PR adds an initial database schema, based on the understanding of the data provided by Daniel. Unfortunately, given that we do not have the pro version, I cannot share it via the website.

To edit the schema, visit https://dbdiagram.io/d and paste the text. It is also possible to extract to Postgres when we consider it done