### PR TITLE
feat: add initial db setup using sqlalchemy

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,27 @@
+from sqlalchemy.ext.automap import automap_base
+from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy import create_engine
+import os
+
+
+Base = automap_base()
+engine = create_engine(
+    os.getenv("APP_DATABASE_CONFIG", "sqlite:////data/database.db")
+)
+db_session = scoped_session(
+    sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        bind=engine
+    )
+)
+Base.prepare(autoload_with=engine)
+
+
+Validated = Base.classes.validated
+ValidatedPDB = Base.classes.validated_pdb
+Compounds = Base.classes.compounds
+PredictedUniqueHomologues = Base.classes.predicted_unique_homologues
+Sequences = Base.classes.sequences
+PredictedGroups = Base.classes.predicted_groups
+SensitivityDistributions = Base.classes.sensitivity_distributions

--- a/app/main.py
+++ b/app/main.py
@@ -4,13 +4,15 @@ from flask import (
 )
 import os
 import logging
+from .database import db_session, Validated
+
 
 logger = logging.getLogger(__name__)
 
 
 def create_app(
-    secret_key,
-    message_root,
+    secret_key: str,
+    message_root: str,
 ):
     app = Flask(
         __name__,
@@ -27,16 +29,45 @@ app = create_app(
 )
 
 
+def get_navigation():
+    return [
+        {"href": "#", "label": "Hello world"},
+    ]
+
+
 @app.route('/')
 def root():
+    with db_session() as session:
+        item = session.query(Validated).first()
+        print("Hello world")
+        print(item.validated_id, item.bacmet_id)
+        print(session)
+        print("ja")
+
     return render_template(
         'base.html',
         copyright="Developed by NBIS",
         title="BacMet",
-        navigation=[
-            {"href": "#", "label": "Hello world"},
-        ]
+        navigation=get_navigation()
     )
+
+
+@app.route('/validated/<bacmet_id>')
+def deferred_result(bacmet_id: str):
+    with db_session() as session:
+        validated = session.query(Validated).filter(
+            Validated.bacmet_id == bacmet_id
+        ).first()
+
+        return render_template(
+            'base.html',
+            copyright="Developed by NBIS",
+            title="BacMet",
+            content_text=(
+                f"{validated.bacmet_id}({validated.validated_id}): {validated.gene_name}"
+            ),
+            navigation=get_navigation()
+        )
 
 
 if __name__ == '__main__':

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,2 +1,3 @@
 Flask==3.0.3
 gunicorn==22.0.0
+sqlalchemy==2.0.41

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -23,7 +23,7 @@
   </nav>
   {% endif %}
   <main>
-    {% block content %}{% endblock %}
+    {% block content %}{{ content_text }}{% endblock %}
   </main>
 
   <footer>


### PR DESCRIPTION
This PR closes #25 

It will:
- Add an initial SQLAlchemy setup
- Map the tables to types using SQLAlchemy automap

To test:
- Build the database
- Start the app
- Go to: http://localhost:5000/validated/BAC0020
- Expect very basic information related to the validated object