### PR TITLE
fix: Remove bad UTF-8 characters from CSV data

### DIFF
--- a/scripts/import-validated-compounds.sh
+++ b/scripts/import-validated-compounds.sh
@@ -3,7 +3,6 @@
 set -u
 
 database=$DATABASE
-data_csv_file=$1
 
 echo 'Importing experimentally validated compounds.' >&2
 
@@ -25,10 +24,11 @@ fi
 
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT INT TERM
-# This data needs to be preprocessed to remove empty records
-# and internal headers.
-awk 'NR == 1 || !(/,,,/ || /CAS Number,Chemical Class/)' \
-	"$data_csv_file" >"$tmpdir/data.csv"
+# This data needs to be preprocessed to remove empty records and
+# internal headers.  There are characters that are not UTF-8 (these are
+# dropped).
+iconv -c -t UTF-8 "$1" |
+awk 'NR == 1 || !(/,,,/ || /CAS Number,Chemical Class/)' >"$tmpdir/data.csv"
 
 echo 'Loading data into database...' >&2
 

--- a/scripts/import-validated.sh
+++ b/scripts/import-validated.sh
@@ -24,6 +24,9 @@ fi
 
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT INT TERM
+# This data needs to be preprocessed to remove charecters that are not
+# UTF-8.
+iconv -c -t UTF-8 "$1" >"$tmpdir/data.csv"
 
 echo 'Loading data into database...' >&2
 
@@ -50,7 +53,7 @@ cat <<-'SQL' >"$tmpdir/import.sql"
 	);
 SQL
 
-printf '.import --skip 1 %s import_tmp\n' "$1" >>"$tmpdir/import.sql"
+printf '.import --skip 1 %s import_tmp\n' "$tmpdir/data.csv" >>"$tmpdir/import.sql"
 
 cat <<-'SQL' >>"$tmpdir/import.sql"
 	INSERT INTO validated (

--- a/scripts/import-validated.sh
+++ b/scripts/import-validated.sh
@@ -24,7 +24,7 @@ fi
 
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT INT TERM
-# This data needs to be preprocessed to remove charecters that are not
+# This data needs to be preprocessed to remove characters that are not
 # UTF-8.
 iconv -c -t UTF-8 "$1" >"$tmpdir/data.csv"
 


### PR DESCRIPTION
This PR closes #34 

Using `iconv`, the two problematic CSV files with characters that are not UTF-8, are filtered to remove the offending characters.

Without this PR, searching for, e.g., `chrBACF`, generates an internal server error. With the PR applied, the error goes away.

