### PR TITLE
33 normalise validated compounds

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,5 +1,5 @@
 from sqlalchemy.ext.automap import automap_base
-from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.orm import scoped_session, sessionmaker, relationship
 from sqlalchemy import create_engine
 import os
 
@@ -21,7 +21,15 @@ Base.prepare(autoload_with=engine)
 Validated = Base.classes.validated
 ValidatedPDB = Base.classes.validated_pdb
 Compounds = Base.classes.compounds
+ValidatedCompounds = Base.classes.validated_compounds
 PredictedUniqueHomologues = Base.classes.predicted_unique_homologues
 Sequences = Base.classes.sequences
 PredictedGroups = Base.classes.predicted_groups
 SensitivityDistributions = Base.classes.sensitivity_distributions
+
+Validated.compounds = relationship(
+    'compounds',
+    secondary=ValidatedCompounds.__table__,
+    backref='validated',
+    viewonly=True
+)

--- a/app/search.py
+++ b/app/search.py
@@ -17,7 +17,7 @@ def find_in_validated(
         if chemical_class:
             items = items.filter(
                 Validated.compounds.any(
-                    Compounds.compound_name.ilike(f"%{chemical_class}%")
+                    Compounds.chemical_class.ilike(f"%{chemical_class}%")
                 )
             )
         if protein_description:

--- a/app/search.py
+++ b/app/search.py
@@ -16,7 +16,9 @@ def find_in_validated(
         items = session.query(Validated)
         if chemical_class:
             items = items.filter(
-                Validated.compound.ilike(f"%{chemical_class}%")
+                Validated.compounds.any(
+                    Compounds.compound_name.ilike(f"%{chemical_class}%")
+                )
             )
         if protein_description:
             items = items.filter(

--- a/scripts/import-all.sh
+++ b/scripts/import-all.sh
@@ -12,11 +12,11 @@ then
 	sqlite3 "$DATABASE" <sql/schema.sql
 fi
 
-import-validated.sh \
-	/data-import/1-Experimentally_validated/1-BacMet_experimentally_validated_database_3.0.csv
-
 import-validated-compounds.sh \
 	/data-import/1-Experimentally_validated/2-BacMet_compound_CAS_numbers.csv
+
+import-validated.sh \
+	/data-import/1-Experimentally_validated/1-BacMet_experimentally_validated_database_3.0.csv
 
 import-validated-pdb-files.sh \
 	/data-import/1-Experimentally_validated/Experimentally_validated_PDB_files.zip

--- a/scripts/import-validated.sh
+++ b/scripts/import-validated.sh
@@ -25,8 +25,19 @@ fi
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT INT TERM
 # This data needs to be preprocessed to remove characters that are not
-# UTF-8.
-iconv -c -t UTF-8 "$1" >"$tmpdir/data.csv"
+# UTF-8 and to correct some misspellt terms.
+iconv -c -t UTF-8 "$1" |
+mlr --csv put '
+	$Compound = gssub($Compound,
+		"Benzylkonium Chloride (BAC)", 
+		"Benzalkonium Chloride (BAC)");
+	$Compound = gssub($Compound,
+		"Benzalkonium chloride",
+		"Benzalkonium Chloride (BAC)");
+	$Compound = gssub($Compound,
+		"Carbonyl cyanide 3-chlorophenylhydrazone (CCCP)",
+		"Carbonyl cyanide (3-chlorophenyl)hydrazone (CCCP)");
+	' >"$tmpdir/data.csv"
 
 echo 'Loading data into database...' >&2
 
@@ -74,7 +85,7 @@ SQL
 
 # Create the relationships table between "validated" and "compounds".
 mlr --csv cut -f 'BacMet ID,Compound' then \
-	nest -f Compound --evar ', ' "$1" \
+	nest -f Compound --evar ', ' "$tmpdir/data.csv" \
 	>"$tmpdir/validated_compounds.csv"
 
 cat <<-'SQL' >>"$tmpdir/import.sql"

--- a/scripts/import-validated.sh
+++ b/scripts/import-validated.sh
@@ -72,6 +72,30 @@ cat <<-'SQL' >>"$tmpdir/import.sql"
 	FROM import_tmp;
 SQL
 
+# Create the relationships table between "validated" and "compounds".
+mlr --csv cut -f 'BacMet ID,Compound' then \
+	nest -f Compound --evar ', ' "$1" \
+	>"$tmpdir/validated_compounds.csv"
+
+cat <<-'SQL' >>"$tmpdir/import.sql"
+	CREATE TEMPORARY TABLE validated_compounds_tmp (
+		bacmet_id TEXT NOT NULL,
+		compound_name TEXT NOT NULL,
+		UNIQUE (bacmet_id, compound_name)
+	);
+SQL
+
+printf '.import --skip 1 %s validated_compounds_tmp\n' \
+	"$tmpdir/validated_compounds.csv" >>"$tmpdir/import.sql"
+
+cat <<-'SQL' >>"$tmpdir/import.sql"
+	INSERT INTO validated_compounds (validated_id, compound_id)
+	SELECT v.validated_id, c.compound_id
+	FROM validated v
+	JOIN validated_compounds_tmp tmp ON v.bacmet_id = tmp.bacmet_id
+	JOIN compounds c ON tmp.compound_name = c.compound_name;
+SQL
+
 sqlite3 "$database" <"$tmpdir/import.sql"
 
 echo 'Done.' >&2

--- a/scripts/import-validated.sh
+++ b/scripts/import-validated.sh
@@ -60,14 +60,14 @@ cat <<-'SQL' >>"$tmpdir/import.sql"
 		bacmet_id, gene_name, code_for, family,
 		protein_accession_ncbi, nucleotide_accession_ena_embl,
 		protein_accession_uniprot, organism, location,
-		type_of_compounds, compound, description, length_aa,
+		type_of_compounds, description, length_aa,
 		reference
 	)
 	SELECT 
 		bacmet_id, gene_name, code_for, family,
 		protein_accession_ncbi, nucleotide_accession_ena_embl,
 		protein_accession_uniprot, organism, location,
-		type_of_compounds, compound, description, length_aa,
+		type_of_compounds, description, length_aa,
 		reference
 	FROM import_tmp;
 SQL

--- a/scripts/import-validated.sh
+++ b/scripts/import-validated.sh
@@ -25,7 +25,7 @@ fi
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT INT TERM
 # This data needs to be preprocessed to remove characters that are not
-# UTF-8 and to correct some misspellt terms.
+# UTF-8 and to correct some misspelled terms.
 iconv -c -t UTF-8 "$1" |
 mlr --csv put '
 	$Compound = gssub($Compound,

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -32,10 +32,12 @@ CREATE TABLE validated (
 
 DROP TABLE IF EXISTS validated_compounds;
 CREATE TABLE validated_compounds (
+	validated_compound_id INTEGER NOT NULL,
 	validated_id INTEGER NOT NULL,
 	compound_id INTEGER NOT NULL,
 
-	PRIMARY KEY(validated_id, compound_id),
+	PRIMARY KEY(validated_compound_id),
+	UNIQUE(validated_id, compound_id),
 	FOREIGN KEY(validated_id) REFERENCES
 		validated(validated_id),
 	FOREIGN KEY(compound_id) REFERENCES

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,3 +1,15 @@
+DROP TABLE IF EXISTS compounds;
+CREATE TABLE compounds (
+	compound_id INTEGER NOT NULL,
+	compound_name TEXT NOT NULL,
+	cas_number TEXT NOT NULL,
+	chemical_class TEXT NOT NULL,
+	description TEXT NOT NULL,
+
+	PRIMARY KEY(compound_id),
+	UNIQUE(compound_name)
+);
+
 DROP TABLE IF EXISTS validated;
 CREATE TABLE validated (
 	validated_id INTEGER NOT NULL,
@@ -28,18 +40,6 @@ CREATE TABLE validated_pdb (
 	PRIMARY KEY(validated_pdb_id),
 	FOREIGN KEY(validated_id) REFERENCES
 		validated(validated_id)
-);
-
-DROP TABLE IF EXISTS compounds;
-CREATE TABLE compounds (
-	compound_id INTEGER NOT NULL,
-	compound_name TEXT NOT NULL,
-	cas_number TEXT NOT NULL,
-	chemical_class TEXT NOT NULL,
-	description TEXT NOT NULL,
-
-	PRIMARY KEY(compound_id),
-	UNIQUE(compound_name)
 );
 
 DROP TABLE IF EXISTS predicted_unique_homologues;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -32,11 +32,10 @@ CREATE TABLE validated (
 
 DROP TABLE IF EXISTS validated_compounds;
 CREATE TABLE validated_compounds (
-	validated_compound_id INTEGER NOT NULL,
 	validated_id INTEGER NOT NULL,
 	compound_id INTEGER NOT NULL,
 
-	PRIMARY KEY(validated_compound_id),
+	PRIMARY KEY(validated_id, compound_id),
 	FOREIGN KEY(validated_id) REFERENCES
 		validated(validated_id),
 	FOREIGN KEY(compound_id) REFERENCES
@@ -45,11 +44,10 @@ CREATE TABLE validated_compounds (
 
 DROP TABLE IF EXISTS validated_pdb;
 CREATE TABLE validated_pdb (
-	validated_pdb_id INTEGER NOT NULL,
 	validated_id INTEGER NOT NULL,
 	pdb TEXT NOT NULL,
 
-	PRIMARY KEY(validated_pdb_id),
+	PRIMARY KEY(validated_id),
 	FOREIGN KEY(validated_id) REFERENCES
 		validated(validated_id)
 );

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -30,6 +30,19 @@ CREATE TABLE validated (
 	PRIMARY KEY(validated_id)
 );
 
+DROP TABLE IF EXISTS validated_compounds;
+CREATE TABLE validated_compounds (
+	validated_compound_id INTEGER NOT NULL,
+	validated_id INTEGER NOT NULL,
+	compound_id INTEGER NOT NULL,
+
+	PRIMARY KEY(validated_compound_id),
+	FOREIGN KEY(validated_id) REFERENCES
+		validated(validated_id),
+	FOREIGN KEY(compound_id) REFERENCES
+		compounds(compound_id)
+);
+
 DROP TABLE IF EXISTS validated_pdb;
 CREATE TABLE validated_pdb (
 	validated_pdb_id INTEGER NOT NULL,

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -23,7 +23,6 @@ CREATE TABLE validated (
 	organism TEXT NOT NULL,
 	location TEXT NOT NULL,
 	type_of_compounds TEXT NOT NULL,
-	compound TEXT NOT NULL,
 	description TEXT NOT NULL,
 	length_aa INTEGER NOT NULL,
 	reference TEXT NOT NULL,


### PR DESCRIPTION
This PR closes #33 

This PR introduces an N:M relations table, `validated_compounds`, which connects the `validated` and `compounds` tables.  The relations are created from the comma-delimited "Compounds" list that is found in the original data.

The PR also modifies the data to correct three incorrectly entered compound names:

* `Benzylkonium Chloride (BAC)` --> `Benzalkonium Chloride (BAC)`
* `Benzalkonium chloride` --> `Benzalkonium Chloride (BAC)`
* `Carbonyl cyanide 3-chlorophenylhydrazone (CCCP)` --> `Carbonyl cyanide (3-chlorophenyl)hydrazone (CCCP)`