### PR TITLE
Add predicted database search

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from flask import (  # type: ignore
     Flask,
     render_template,
     request,
+    url_for,
 )
 import os
 import logging
@@ -14,7 +15,7 @@ from .search import (
     get_chemical_classes,
     get_compounds
 )
-from typing import Any, Optional
+from typing import Any, Optional, Literal
 from .types import FormField, FormFieldValue
 
 
@@ -28,9 +29,17 @@ class MenuItem:
 
 
 @dataclasses.dataclass
+class ResultPage:
+    state: Optional[Literal["active", "disabled"]] = None
+    label: Optional[str] = None
+    url: Optional[str] = None
+
+
+@dataclasses.dataclass
 class SearchResult:
     status: Optional[str] = None
     items: Optional[Any] = None
+    pages: Optional[list[ResultPage]] = None
 
 
 def create_app(
@@ -99,27 +108,62 @@ def advanced_search():
         request.args.get("peptide_sequence_length_min"),
         request.args.get("peptide_sequence_length_max")
     ))
-    items = (
+    page = int(request.args.get("page", "0"))
+    page_size = min(100, int(request.args.get("page_size", "25")))
+    items, total_count = (
         find_in_validated(
             chemical_class=chemical_class,
             location=location,
             protein_description=protein_description,
-            peptide_sequence_length_range=peptide_sequence_length_range
+            peptide_sequence_length_range=peptide_sequence_length_range,
+            pagination=(page, page_size)
         ) if database == "validated"
         else find_in_predicted(
             chemical_class=chemical_class,
             location=location,
             protein_description=protein_description,
+            pagination=(page, page_size)
         )
-    ) if database else None
+    ) if database else (None, -1)
     chemical_classes = get_chemical_classes()
     compounds = get_compounds()
 
+    pages_to_list = 5
+    page_list_start = max(1, page - int(pages_to_list / 2))
+    last_page = int(total_count / page_size)
+    args = request.args.to_dict()
     search_result = (
         None if items is None
         else SearchResult(
-            status=None if len(items) > 0 else "No results found",
-            items=items
+            status=(
+                f"Showing {len(items)} of {total_count} items."
+                if len(items) > 0
+                else "No results found."
+            ),
+            items=[
+                item[0]
+                for item in items
+            ],
+            pages=[
+                ResultPage(
+                    label=f"First",
+                    state="active" if page == 0 else None,
+                    url=url_for("advanced_search", **{**args, "page": 0})
+                ),
+                *[
+                    ResultPage(
+                        label=f"{i + 1}",
+                        state="active" if page == i else None,
+                        url=url_for("advanced_search", **{**args, "page": i})
+                    )
+                    for i in range(page_list_start, min(page_list_start + pages_to_list, last_page))
+                ],
+                ResultPage(
+                    label=f"Last",
+                    state="active" if page == last_page else None,
+                    url=url_for("advanced_search", **{**args, "page": last_page})
+                )
+            ],
         )
     )
 

--- a/app/main.py
+++ b/app/main.py
@@ -178,11 +178,8 @@ def advanced_search():
                 "Peptide sequence length greater than "
                 "(for EXP confirmed database only)"
             ),
-            value=(
-                50
-                if peptide_sequence_length_range[0] is None
-                else peptide_sequence_length_range[0]
-            )
+            value=peptide_sequence_length_range[0],
+            placeholder=50,
         ),
         FormField(
             name="peptide_sequence_length_max",
@@ -190,11 +187,8 @@ def advanced_search():
                 "Peptide sequence length less than "
                 "(for EXP confirmed database only)"
             ),
-            value=(
-                2000
-                if peptide_sequence_length_range[1] is None
-                else peptide_sequence_length_range[1]
-            )
+            value=peptide_sequence_length_range[1],
+            placeholder=2000
         ),
     ]
     return render_template(

--- a/app/main.py
+++ b/app/main.py
@@ -146,7 +146,7 @@ def advanced_search():
             ],
             pages=[
                 ResultPage(
-                    label=f"First",
+                    label="First",
                     state="active" if page == 0 else None,
                     url=url_for("advanced_search", **{**args, "page": 0})
                 ),
@@ -156,12 +156,18 @@ def advanced_search():
                         state="active" if page == i else None,
                         url=url_for("advanced_search", **{**args, "page": i})
                     )
-                    for i in range(page_list_start, min(page_list_start + pages_to_list, last_page))
+                    for i in range(
+                        page_list_start,
+                        min(page_list_start + pages_to_list, last_page)
+                    )
                 ],
                 ResultPage(
-                    label=f"Last",
+                    label="Last",
                     state="active" if page == last_page else None,
-                    url=url_for("advanced_search", **{**args, "page": last_page})
+                    url=url_for(
+                        "advanced_search",
+                        **{**args, "page": last_page}
+                    )
                 )
             ],
         )

--- a/app/main.py
+++ b/app/main.py
@@ -137,7 +137,7 @@ def advanced_search():
         None if items is None
         else SearchResult(
             status=(
-                f"Showing {len(items)} of {total_count} items."
+                f"Showing {len(items)} of {total_count} items. On page {page + 1} of {last_page + 1}."
                 if len(items) > 0
                 else "No results found."
             ),

--- a/app/main.py
+++ b/app/main.py
@@ -169,7 +169,7 @@ def advanced_search():
                         **{**args, "page": last_page}
                     )
                 )
-            ],
+            ] if last_page > 0 else None,
         )
     )
 
@@ -192,12 +192,12 @@ def advanced_search():
         FormField(
             name="chemical_class",
             label="Select 'chemical class' / 'compound' (resistant to)",
-            value=chemical_class,
+            value=":".join(chemical_class) if chemical_class else "",
             values=[
                 FormFieldValue(value="", label="class: Any"),
                 *[
-                    FormFieldValue(value=v, label=v)
-                    for v in [
+                    FormFieldValue(value=value, label=label)
+                    for (label, value) in [
                         *chemical_classes,
                         *compounds
                     ]

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from flask import (  # type: ignore
 import os
 import logging
 import dataclasses
+import math
 from .database import db_session, Validated
 from . import parsers
 from .search import (
@@ -130,7 +131,7 @@ def advanced_search():
 
     pages_to_list = 5
     page_list_start = max(1, page - int(pages_to_list / 2))
-    last_page = int(total_count / page_size)
+    last_page = math.ceil(total_count / page_size) - 1
     args = request.args.to_dict()
     search_result = (
         None if items is None

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from flask import (
+from flask import (  # type: ignore
     Flask,
     render_template,
     request,

--- a/app/main.py
+++ b/app/main.py
@@ -140,10 +140,7 @@ def advanced_search():
                 if len(items) > 0
                 else "No results found."
             ),
-            items=[
-                item[0]
-                for item in items
-            ],
+            items=items,
             pages=[
                 ResultPage(
                     label="First",

--- a/app/parsers.py
+++ b/app/parsers.py
@@ -39,6 +39,6 @@ def peptide_sequence_length_range(
     data: (str, str)
 ) -> Optional[Tuple[int | None, int | None]]:
     min_len, max_len = data
-    min_len = None if min_len is None else int(min_len)
-    max_len = None if max_len is None else int(max_len)
+    min_len = None if not min_len else int(min_len)
+    max_len = None if not max_len else int(max_len)
     return min_len, max_len

--- a/app/parsers.py
+++ b/app/parsers.py
@@ -1,10 +1,10 @@
-from typing import Literal, Optional, Tuple
+from typing import cast, Literal, Optional, Tuple
 
 
-def database(data: str) -> Literal["validated", "predicted"]:
+def database(data: str) -> Optional[Literal["validated", "predicted"]]:
     value = None if data is None else data.lower()
     if value in {None, "validated", "predicted"}:
-        return value
+        return cast(Literal["validated", "predicted"], value)
 
     raise ValueError(f"Could not parse location: {value}")
 
@@ -16,7 +16,7 @@ def chemical_class(data: str) -> Optional[str]:
 def location(
     data: str,
     database: Literal["validated", "predicted"]
-) -> Literal["any", "chromosome"]:
+) -> Optional[Literal["any", "chromosome"]]:
     value = None if data is None else data.lower()
     allowed_values = (
         {"any", "chromosome", "plasmid"}
@@ -24,7 +24,9 @@ def location(
         else {"any", "chromosome"}
     )
     if value is None or value in allowed_values:
-        return None if value == "any" else value
+        return None if value == "any" else cast(
+            Literal["any", "chromosome"], value
+        )
 
     raise ValueError(
         f"Could not parse location: {value} for database: {database}"
@@ -36,9 +38,9 @@ def protein_description(data: str) -> Optional[str]:
 
 
 def peptide_sequence_length_range(
-    data: (str, str)
+    data: Tuple[str, str]
 ) -> Optional[Tuple[int | None, int | None]]:
-    min_len, max_len = data
-    min_len = None if not min_len else int(min_len)
-    max_len = None if not max_len else int(max_len)
+    min_len_str, max_len_str = data
+    min_len = None if not min_len_str else int(min_len_str)
+    max_len = None if not max_len_str else int(max_len_str)
     return min_len, max_len

--- a/app/parsers.py
+++ b/app/parsers.py
@@ -7,7 +7,7 @@ def database(data: str) -> Optional[DatabaseOption]:
     if value in {None, "validated", "predicted"}:
         return cast(DatabaseOption, value)
 
-    raise ValueError(f"Could not parse location: {value}")
+    raise ValueError(f"Could not parse database: {value}")
 
 
 def chemical_class(data: str) -> (
@@ -21,7 +21,7 @@ def chemical_class(data: str) -> (
     else:
         return None
 
-    raise ValueError(f"Could not parse chemical_class: {value}")
+    raise ValueError(f"Could not parse chemical_class: {data}")
 
 
 def location(

--- a/app/parsers.py
+++ b/app/parsers.py
@@ -14,7 +14,8 @@ def chemical_class(data: str) -> (
     Optional[Tuple[ChemicalClassType, str]]
 ):
     if data:
-        [value_type_str, *value] = data.lower().split(":")
+        [value_type_str, *value] = data.split(":")
+        value_type_str = value_type_str.lower()
         if value_type_str in {"class", "compound"}:
             value_type = cast(ChemicalClassType, value_type_str)
             return value_type, ":".join(value)

--- a/app/parsers.py
+++ b/app/parsers.py
@@ -1,22 +1,33 @@
-from typing import cast, Literal, Optional, Tuple
+from typing import cast,  Optional, Tuple
+from .types import DatabaseOption, ChemicalClassType, LocationOption, OpenRange
 
 
-def database(data: str) -> Optional[Literal["validated", "predicted"]]:
+def database(data: str) -> Optional[DatabaseOption]:
     value = None if data is None else data.lower()
     if value in {None, "validated", "predicted"}:
-        return cast(Literal["validated", "predicted"], value)
+        return cast(DatabaseOption, value)
 
     raise ValueError(f"Could not parse location: {value}")
 
 
-def chemical_class(data: str) -> Optional[str]:
-    return data
+def chemical_class(data: str) -> (
+    Optional[Tuple[ChemicalClassType, str]]
+):
+    if data:
+        [value_type_str, *value] = data.lower().split(":")
+        if value_type_str in {"class", "compound"}:
+            value_type = cast(ChemicalClassType, value_type_str)
+            return value_type, ":".join(value)
+    else:
+        return None
+
+    raise ValueError(f"Could not parse chemical_class: {value}")
 
 
 def location(
     data: str,
-    database: Literal["validated", "predicted"]
-) -> Optional[Literal["any", "chromosome"]]:
+    database: DatabaseOption
+) -> Optional[LocationOption]:
     value = None if data is None else data.lower()
     allowed_values = (
         {"any", "chromosome", "plasmid"}
@@ -25,7 +36,7 @@ def location(
     )
     if value is None or value in allowed_values:
         return None if value == "any" else cast(
-            Literal["any", "chromosome"], value
+           LocationOption, value
         )
 
     raise ValueError(
@@ -39,7 +50,7 @@ def protein_description(data: str) -> Optional[str]:
 
 def peptide_sequence_length_range(
     data: Tuple[str, str]
-) -> Optional[Tuple[int | None, int | None]]:
+) -> Optional[OpenRange]:
     min_len_str, max_len_str = data
     min_len = None if not min_len_str else int(min_len_str)
     max_len = None if not max_len_str else int(max_len_str)

--- a/app/search.py
+++ b/app/search.py
@@ -73,7 +73,7 @@ def find_in_validated(
     pagination: Tuple[int, int]
 ) -> Tuple[list[Validated], int]:
     stmt = apply_search_filters(
-        select(Validated),
+        select(Validated).order_by(Validated.validated_id),
         chemical_class,
         location,
         protein_description,
@@ -95,7 +95,7 @@ def find_in_predicted(
         select(
             Validated,
             PredictedUniqueHomologues,
-        ).join(
+        ).order_by(PredictedUniqueHomologues.predicted_unique_homologue_id).join(
             Validated,
             PredictedUniqueHomologues.validated_id == Validated.validated_id
         ),

--- a/app/search.py
+++ b/app/search.py
@@ -1,9 +1,59 @@
+from sqlalchemy import select
+from sqlalchemy.sql import func
 from typing import Literal, Optional, Tuple
 from .database import (
     db_session,
     Validated,
+    PredictedUniqueHomologues,
     Compounds
 )
+
+
+def apply_search_filters(
+    stmt,
+    chemical_class: Optional[str],
+    location: Literal["any", "chromosome", "plasmid"],
+    protein_description: Optional[str],
+    peptide_sequence_length_range: Optional[Tuple[int | None, int | None]],
+):
+    if chemical_class:
+        stmt = stmt.filter(
+            Validated.compounds.any(
+                Compounds.compound_name.ilike(f"%{chemical_class}%")
+            )
+        )
+    if protein_description:
+        stmt = stmt.filter(
+            Validated.description.ilike(f"%{protein_description}%")
+        )
+    if location and location != "any":
+        stmt = stmt.filter(
+            Validated.location.ilike(f"%{location}%")
+        )
+    if peptide_sequence_length_range:
+        min_length, max_length = peptide_sequence_length_range
+        if min_length is not None:
+            stmt = stmt.filter(
+                Validated.length_aa > min_length
+            )
+        if max_length is not None:
+            stmt = stmt.filter(
+                Validated.length_aa < max_length
+            )
+    return stmt
+
+
+def apply_pagination(stmt, pagination: Tuple[int, int]):
+    page, page_size = pagination
+    return (
+        stmt
+        .limit(page_size)
+        .offset(page * page_size)
+    )
+
+
+def apply_total_count(stmt):
+    return select(func.count()).select_from(stmt.subquery())
 
 
 def find_in_validated(
@@ -11,43 +61,44 @@ def find_in_validated(
     location: Literal["any", "chromosome", "plasmid"],
     protein_description: Optional[str],
     peptide_sequence_length_range: Optional[Tuple[int | None, int | None]],
-) -> list[Validated]:
+    pagination: Tuple[int, int]
+) -> Tuple[list[Validated], int]:
+    stmt = apply_search_filters(
+        select(Validated),
+        chemical_class,
+        location,
+        protein_description,
+        peptide_sequence_length_range
+    )
     with db_session() as session:
-        items = session.query(Validated)
-        if chemical_class:
-            items = items.filter(
-                Validated.compounds.any(
-                    Compounds.chemical_class.ilike(f"%{chemical_class}%")
-                )
-            )
-        if protein_description:
-            items = items.filter(
-                Validated.description.ilike(f"%{protein_description}%")
-            )
-        if location and location != "any":
-            items = items.filter(
-                Validated.location.ilike(f"%{location}%")
-            )
-        if peptide_sequence_length_range:
-            min_length, max_length = peptide_sequence_length_range
-            if min_length is not None:
-                items = items.filter(
-                    Validated.length_aa > min_length
-                )
-            if max_length is not None:
-                items = items.filter(
-                    Validated.length_aa < max_length
-                )
-        return list(items)
+        items = session.execute(apply_pagination(stmt, pagination)).all()
+        total_count = session.execute(apply_total_count(stmt)).scalar()
+        return (list(items), total_count)
 
 
 def find_in_predicted(
     chemical_class: Optional[str],
     location: Literal["any", "chromosome"],
     protein_description: Optional[str],
-):
-    # TODO: Not implemented yet
-    return []
+    pagination: Tuple[int, int]
+) -> Tuple[list[Tuple[Validated, PredictedUniqueHomologues]], int]:
+    stmt = apply_search_filters(
+        select(
+            Validated,
+            PredictedUniqueHomologues,
+        ).join(
+            Validated,
+            PredictedUniqueHomologues.validated_id == Validated.validated_id
+        ),
+        chemical_class,
+        location,
+        protein_description,
+        (None, None)
+    )
+    with db_session() as session:
+        items = session.execute(apply_pagination(stmt, pagination)).all()
+        total_count = session.execute(apply_total_count(stmt)).scalar()
+        return (list(items), total_count)
 
 
 def get_chemical_classes():

--- a/app/search.py
+++ b/app/search.py
@@ -6,9 +6,11 @@ from .database import (
     db_session,
     Validated,
     PredictedUniqueHomologues,
-    Compounds
+    Compounds,
+    ValidatedCompounds
 )
 from .types import LocationOption, OpenRange, ChemicalClass
+from functools import cache
 
 
 def apply_search_filters(
@@ -20,18 +22,13 @@ def apply_search_filters(
 ):
     if chemical_class:
         chemical_class_type, chemical_class_name = chemical_class
-        if chemical_class_type == "class":
-            stmt = stmt.filter(
-                Validated.compounds.any(
-                    Compounds.chemical_class.ilike(f"%{chemical_class_name}%")
-                )
+        stmt = stmt.filter(
+            Validated.compounds.any(
+                Compounds.compound_name == chemical_class_name
+                if chemical_class_type == "compound"
+                else Compounds.chemical_class == chemical_class_name
             )
-        elif chemical_class_type == "compound":
-            stmt = stmt.filter(
-                Validated.compounds.any(
-                    Compounds.compound_name.ilike(f"%{chemical_class_name}%")
-                )
-            )
+        )
     if protein_description:
         stmt = stmt.filter(
             Validated.description.ilike(f"%{protein_description}%")
@@ -119,19 +116,25 @@ def find_in_predicted(
         return (list(items), total_count)
 
 
+@cache
 def get_chemical_classes() -> list[Tuple[str, str]]:
+    all_compounds = select(ValidatedCompounds.compound_id).distinct().subquery()
+    stmt = select(Compounds.chemical_class).filter(Compounds.compound_id.in_(all_compounds)).distinct()
     with db_session() as session:
-        chemical_classes = session.query(Compounds.chemical_class).distinct()
+        chemical_classes = session.execute(stmt)
         return [
-            (f"class: {cc}", f"class:{cc.lower()}")
+            (f"class: {cc}", f"class:{cc}")
             for cc, in chemical_classes
         ]
 
 
+@cache
 def get_compounds() -> list[Tuple[str, str]]:
+    all_compounds = select(ValidatedCompounds.compound_id).distinct().subquery()
+    stmt = select(Compounds.compound_name).filter(Compounds.compound_id.in_(all_compounds)).distinct()
     with db_session() as session:
-        compound_names = session.query(Compounds.compound_name).distinct()
+        compound_names = session.execute(stmt)
         return [
-            (cn, f"compound:{cn.lower()}")
+            (cn, f"compound:{cn}")
             for cn, in compound_names
         ]

--- a/app/search.py
+++ b/app/search.py
@@ -1,5 +1,6 @@
 from sqlalchemy import select
 from sqlalchemy.sql import func
+from sqlalchemy.orm import joinedload
 from typing import Optional, Tuple
 from .database import (
     db_session,
@@ -73,14 +74,18 @@ def find_in_validated(
     pagination: Tuple[int, int]
 ) -> Tuple[list[Validated], int]:
     stmt = apply_search_filters(
-        select(Validated).order_by(Validated.validated_id),
+        select(Validated).options(
+            joinedload(Validated.compounds)
+        ).order_by(Validated.validated_id),
         chemical_class,
         location,
         protein_description,
         peptide_sequence_length_range
     )
     with db_session() as session:
-        items = session.execute(apply_pagination(stmt, pagination)).all()
+        items = session.execute(
+            apply_pagination(stmt, pagination)
+        ).unique().all()
         total_count = session.execute(apply_total_count(stmt)).scalar()
         return (list(items), total_count)
 
@@ -95,7 +100,11 @@ def find_in_predicted(
         select(
             Validated,
             PredictedUniqueHomologues,
-        ).order_by(PredictedUniqueHomologues.predicted_unique_homologue_id).join(
+        ).options(
+            joinedload(Validated.compounds)
+        ).order_by(
+            PredictedUniqueHomologues.predicted_unique_homologue_id
+        ).join(
             Validated,
             PredictedUniqueHomologues.validated_id == Validated.validated_id
         ),
@@ -105,7 +114,7 @@ def find_in_predicted(
         (None, None)
     )
     with db_session() as session:
-        items = session.execute(apply_pagination(stmt, pagination)).all()
+        items = session.execute(apply_pagination(stmt, pagination)).unique().all()
         total_count = session.execute(apply_total_count(stmt)).scalar()
         return (list(items), total_count)
 

--- a/app/search.py
+++ b/app/search.py
@@ -1,27 +1,36 @@
 from sqlalchemy import select
 from sqlalchemy.sql import func
-from typing import Literal, Optional, Tuple
+from typing import Optional, Tuple
 from .database import (
     db_session,
     Validated,
     PredictedUniqueHomologues,
     Compounds
 )
+from .types import LocationOption, OpenRange, ChemicalClass
 
 
 def apply_search_filters(
     stmt,
-    chemical_class: Optional[str],
-    location: Literal["any", "chromosome", "plasmid"],
+    chemical_class: Optional[ChemicalClass],
+    location: Optional[LocationOption],
     protein_description: Optional[str],
-    peptide_sequence_length_range: Optional[Tuple[int | None, int | None]],
+    peptide_sequence_length_range: Optional[OpenRange],
 ):
     if chemical_class:
-        stmt = stmt.filter(
-            Validated.compounds.any(
-                Compounds.compound_name.ilike(f"%{chemical_class}%")
+        chemical_class_type, chemical_class_name = chemical_class
+        if chemical_class_type == "class":
+            stmt = stmt.filter(
+                Validated.compounds.any(
+                    Compounds.chemical_class.ilike(f"%{chemical_class_name}%")
+                )
             )
-        )
+        elif chemical_class_type == "compound":
+            stmt = stmt.filter(
+                Validated.compounds.any(
+                    Compounds.compound_name.ilike(f"%{chemical_class_name}%")
+                )
+            )
     if protein_description:
         stmt = stmt.filter(
             Validated.description.ilike(f"%{protein_description}%")
@@ -57,10 +66,10 @@ def apply_total_count(stmt):
 
 
 def find_in_validated(
-    chemical_class: Optional[str],
-    location: Literal["any", "chromosome", "plasmid"],
+    chemical_class: Optional[ChemicalClass],
+    location: Optional[LocationOption],
     protein_description: Optional[str],
-    peptide_sequence_length_range: Optional[Tuple[int | None, int | None]],
+    peptide_sequence_length_range: Optional[OpenRange],
     pagination: Tuple[int, int]
 ) -> Tuple[list[Validated], int]:
     stmt = apply_search_filters(
@@ -77,8 +86,8 @@ def find_in_validated(
 
 
 def find_in_predicted(
-    chemical_class: Optional[str],
-    location: Literal["any", "chromosome"],
+    chemical_class: Optional[ChemicalClass],
+    location: Optional[LocationOption],
     protein_description: Optional[str],
     pagination: Tuple[int, int]
 ) -> Tuple[list[Tuple[Validated, PredictedUniqueHomologues]], int]:
@@ -101,19 +110,19 @@ def find_in_predicted(
         return (list(items), total_count)
 
 
-def get_chemical_classes():
+def get_chemical_classes() -> list[Tuple[str, str]]:
     with db_session() as session:
         chemical_classes = session.query(Compounds.chemical_class).distinct()
         return [
-            f"class: {cc}"
+            (f"class: {cc}", f"class:{cc.lower()}")
             for cc, in chemical_classes
         ]
 
 
-def get_compounds():
+def get_compounds() -> list[Tuple[str, str]]:
     with db_session() as session:
         compound_names = session.query(Compounds.compound_name).distinct()
         return [
-            cn
+            (cn, f"compound:{cn.lower()}")
             for cn, in compound_names
         ]

--- a/app/search.py
+++ b/app/search.py
@@ -36,7 +36,7 @@ def apply_search_filters(
         stmt = stmt.filter(
             Validated.description.ilike(f"%{protein_description}%")
         )
-    if location and location != "any":
+    if location:
         stmt = stmt.filter(
             Validated.location.ilike(f"%{location}%")
         )

--- a/app/templates/search_result.html
+++ b/app/templates/search_result.html
@@ -69,9 +69,13 @@
 <hr />
 {% with pages = result.pages %}{% include "snippets/pagination.html" %}{% endwith %}
 <ul>
-    {% for result in result.items %}
-    <li>{{ result.gene_name }}, {{ result.bacmet_id }}</li>
-    {% endfor %}
+    {% for item in result.items %}{% with validated=item[0], predicted=item[1]%}
+    {% if predicted %}
+    <li>{{ predicted.blast_hit_genome }}, {{ validated.gene_name }}, {{ validated.bacmet_id }}</li>
+    {% else %}
+    <li>{{ validated.gene_name }}, {{ validated.bacmet_id }}{% if validated.compounds %}{% for compound in validated.compounds %}, {{ compound.compound_name }} {% endfor %}{% endif %}</li>
+    {% endif %}
+    {% endwith %}{% endfor %}
 </ul>
 {% with pages = result.pages %}{% include "snippets/pagination.html" %}{% endwith %}
 {% endif %}

--- a/app/templates/search_result.html
+++ b/app/templates/search_result.html
@@ -61,11 +61,13 @@
 </form>
 
 {% if result %}
-<hr />
 {% if result.status %}
+<hr />
 <div>{{ result.status }}</div>
 {% endif %}
+{% if result.items %}
 {% if result.pages %}
+<hr />
 <nav aria-label="...">
   <ul class="pagination">
     {% for page in result.pages %}
@@ -76,7 +78,6 @@
   </ul>
 </nav>
 {% endif %}
-{% if result.items %}
 <ul>
     {% for result in result.items %}
     <li>{{ result.gene_name }}, {{ result.bacmet_id }}</li>

--- a/app/templates/search_result.html
+++ b/app/templates/search_result.html
@@ -68,21 +68,14 @@
 {% if result.items %}
 {% if result.pages %}
 <hr />
-<nav aria-label="...">
-  <ul class="pagination">
-    {% for page in result.pages %}
-    <li class="page-item {{ page.state }}">
-      <a class="page-link" href="{{ page.url }}">{{ page.label }}</a>
-    </li>
-    {% endfor %}
-  </ul>
-</nav>
+{% with pages = result.pages %}{% include "snippets/pagination.html" %}{% endwith %}
 {% endif %}
 <ul>
     {% for result in result.items %}
     <li>{{ result.gene_name }}, {{ result.bacmet_id }}</li>
     {% endfor %}
 </ul>
+{% with pages = result.pages %}{% include "snippets/pagination.html" %}{% endwith %}
 {% endif %}
 {% endif %}
 {% endblock %}

--- a/app/templates/search_result.html
+++ b/app/templates/search_result.html
@@ -65,6 +65,17 @@
 {% if result.status %}
 <div>{{ result.status }}</div>
 {% endif %}
+{% if result.pages %}
+<nav aria-label="...">
+  <ul class="pagination">
+    {% for page in result.pages %}
+    <li class="page-item {{ page.state }}">
+      <a class="page-link" href="{{ page.url }}">{{ page.label }}</a>
+    </li>
+    {% endfor %}
+  </ul>
+</nav>
+{% endif %}
 {% if result.items %}
 <ul>
     {% for result in result.items %}

--- a/app/templates/search_result.html
+++ b/app/templates/search_result.html
@@ -66,10 +66,8 @@
 <div>{{ result.status }}</div>
 {% endif %}
 {% if result.items %}
-{% if result.pages %}
 <hr />
 {% with pages = result.pages %}{% include "snippets/pagination.html" %}{% endwith %}
-{% endif %}
 <ul>
     {% for result in result.items %}
     <li>{{ result.gene_name }}, {{ result.bacmet_id }}</li>

--- a/app/templates/search_result.html
+++ b/app/templates/search_result.html
@@ -50,11 +50,11 @@
         <legend class="border-bottom mb-4">Peptide sequence length</legend>
         {% with field = fields.peptide_sequence_length_min %}
         <label class="form-label" for="{{ field.name }}">{{ field.label }}</label>
-        <input class="form-control" type="number" name="{{ field.name }}" value="{{ field.value }}" id="{{ field.name }}">
+        <input class="form-control" type="number" name="{{ field.name }}" placeholder="{{ field.placeholder }}" value="{{ field.value }}" id="{{ field.name }}">
         {% endwith %}
         {% with field = fields.peptide_sequence_length_max %}
         <label class="form-label" for="{{ field.name }}">{{ field.label }}</label>
-        <input class="form-control" type="number" name="{{ field.name }}" value="{{ field.value }}" id="{{ field.name }}">
+        <input class="form-control" type="number" name="{{ field.name }}" placeholder="{{ field.placeholder }}" value="{{ field.value }}" id="{{ field.name }}">
         {% endwith %}
     </fieldset>
     <input class="btn btn-primary" type="submit" value="Search">

--- a/app/templates/snippets/pagination.html
+++ b/app/templates/snippets/pagination.html
@@ -1,0 +1,9 @@
+<nav aria-label="...">
+  <ul class="pagination">
+    {% for page in pages %}
+    <li class="page-item {{ page.state }}">
+      <a class="page-link" href="{{ page.url }}">{{ page.label }}</a>
+    </li>
+    {% endfor %}
+  </ul>
+</nav>

--- a/app/templates/snippets/pagination.html
+++ b/app/templates/snippets/pagination.html
@@ -1,4 +1,4 @@
-<nav aria-label="...">
+{% if pages %}<nav aria-label="...">
   <ul class="pagination">
     {% for page in pages %}
     <li class="page-item {{ page.state }}">
@@ -6,4 +6,4 @@
     </li>
     {% endfor %}
   </ul>
-</nav>
+</nav>{% endif %}

--- a/app/types.py
+++ b/app/types.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Optional
+from typing import Literal, Optional, Tuple
 
 
 @dataclasses.dataclass
@@ -15,3 +15,18 @@ class FormField:
     value: str
     placeholder: Optional[str] = None
     values: Optional[list[FormFieldValue]] = None
+
+
+ChemicalClassType = Literal["class", "compound"]
+
+
+ChemicalClass = Tuple[ChemicalClassType, str]
+
+
+DatabaseOption = Literal["validated", "predicted"]
+
+
+LocationOption = Literal["chromosome", "plasmid"]
+
+
+OpenRange = Tuple[int | None, int | None]

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -9,6 +9,7 @@ CREATE TABLE compounds (
 	PRIMARY KEY(compound_id),
 	UNIQUE(compound_name)
 );
+CREATE INDEX chemical_class_idx ON compounds(chemical_class);
 
 DROP TABLE IF EXISTS validated;
 CREATE TABLE validated (
@@ -37,7 +38,7 @@ CREATE TABLE validated_compounds (
 	compound_id INTEGER NOT NULL,
 
 	PRIMARY KEY(validated_compound_id),
-	UNIQUE(validated_id, compound_id),
+	UNIQUE(compound_id, validated_id),
 	FOREIGN KEY(validated_id) REFERENCES
 		validated(validated_id),
 	FOREIGN KEY(compound_id) REFERENCES
@@ -82,6 +83,7 @@ CREATE TABLE predicted_unique_homologues (
 	FOREIGN KEY(validated_id) REFERENCES
 		validated(validated_id)
 );
+CREATE INDEX validated_idx ON predicted_unique_homologues(validated_id);
 
 DROP TABLE IF EXISTS sequences;
 CREATE TABLE sequences (


### PR DESCRIPTION
This PR closes #29 

It will:
- Clean up search code
- Clean up html
- Clean up typing
- Use statements instead of queries to simplify reuse
- Add pagination
- Add support for searching in the predicted database

To test:
- got to: http://localhost:5000/search
- use the search fields for both databases
- expect results