### PR TITLE
41 update dockerfiles

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -27,7 +27,7 @@ CMD flask --app app/main --debug run --host 0.0.0.0 --port 5000
 # Production setup
 FROM base AS prod
 
-COPY scripts/start-script.sh ./start-script.sh
+COPY --chmod=755 scripts/start-script.sh ./start-script.sh
 
 USER python
 CMD ./start-script.sh

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 ARG UID=1000
 RUN adduser -D -u "$UID" python
 
-EXPOSE ${APP_PORT:-5000}/tcp
+EXPOSE 5000/tcp
 
 
 # Development setup
@@ -20,7 +20,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements.dev.txt
 
 USER python
-CMD flask --app main --debug run --host 0.0.0.0 --port "${APP_PORT:-5000}"
+CMD flask --app main --debug run --host 0.0.0.0 --port 5000
 
 
 # Production setup

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -8,8 +8,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements.txt
 
 ARG UID=1000
-ARG GID=1000
-RUN addgroup -g "$GID" python && adduser -D -u "$UID" -G python python
+RUN adduser -D -u "$UID" python
 
 EXPOSE ${APP_PORT:-5000}/tcp
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,11 +1,12 @@
 # syntax=docker/dockerfile:1.4
 FROM python:3.13-alpine AS base
 
-WORKDIR /opt/bacmet/app
-COPY ./app ./
+WORKDIR /opt/bacmet
+
+COPY ./app ./app
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install -r requirements.txt
+    pip install -r app/requirements.txt
 
 ARG UID=1000
 RUN adduser -D -u "$UID" python
@@ -17,16 +18,14 @@ EXPOSE 5000/tcp
 FROM base AS dev
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install -r requirements.dev.txt
+    pip install -r app/requirements.dev.txt
 
 USER python
-CMD flask --app main --debug run --host 0.0.0.0 --port 5000
+CMD flask --app app/main --debug run --host 0.0.0.0 --port 5000
 
 
 # Production setup
 FROM base AS prod
-
-WORKDIR /opt/bacmet
 
 COPY scripts/start-script.sh ./start-script.sh
 

--- a/app/scripts/start-script.sh
+++ b/app/scripts/start-script.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec gunicorn -w "${APP_WORKERS:-4}" "app:app" -b "0.0.0.0:${APP_PORT:-5000}"
+exec gunicorn -w "${APP_WORKERS:-4}" app:app -b 0.0.0.0:5000

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -4,7 +4,8 @@ RUN apk add --no-cache \
 	sqlite~3 \
 	miller~6
 
-RUN adduser -D database
+ARG UID=1000
+RUN adduser -D -u "$UID" database
 
 RUN mkdir -m 775 /data
 RUN chown database /data

--- a/database/scripts/import-predicted-groups.sh
+++ b/database/scripts/import-predicted-groups.sh
@@ -2,6 +2,7 @@
 
 set -u
 
+# shellcheck disable=SC2153
 database=$DATABASE
 data_zip_archive=$1
 
@@ -42,6 +43,7 @@ cat <<-'SQL' >"$tmpdir/import.sql"
 	);
 SQL
 
+# shellcheck disable=SC2129
 printf '.import --skip 1 %s import_tmp\n' "$tmpdir"/*.csv >>"$tmpdir/import.sql"
 
 cat <<-'SQL' >>"$tmpdir/import.sql"

--- a/database/scripts/import-predicted-unique-homologues.sh
+++ b/database/scripts/import-predicted-unique-homologues.sh
@@ -2,6 +2,7 @@
 
 set -u
 
+# shellcheck disable=SC2153
 database=$DATABASE
 data_zip_archive=$1
 

--- a/database/scripts/import-sensitivity-distributions.sh
+++ b/database/scripts/import-sensitivity-distributions.sh
@@ -2,6 +2,7 @@
 
 set -u
 
+# shellcheck disable=SC2153
 database=$DATABASE
 
 echo 'Importing sensitivity distributions.' >&2
@@ -35,6 +36,7 @@ done
 # * Remove duplicated records,
 # * Move comments from the unnamed field "Unnamed: 13" to the "Comment" field,
 # * Remove empty columns.
+# shellcheck disable=SC1010,SC2016
 mlr --csv \
 	rename 'strain,Strain,Incubation time (),Incubation time (h)' then \
 	uniq -a then \

--- a/database/scripts/import-validated-compounds.sh
+++ b/database/scripts/import-validated-compounds.sh
@@ -2,6 +2,7 @@
 
 set -u
 
+# shellcheck disable=SC2153
 database=$DATABASE
 
 echo 'Importing experimentally validated compounds.' >&2

--- a/database/scripts/import-validated-pdb-files.sh
+++ b/database/scripts/import-validated-pdb-files.sh
@@ -2,6 +2,7 @@
 
 set -u
 
+# shellcheck disable=SC2153
 database=$DATABASE
 data_zip_archive=$1
 

--- a/database/scripts/import-validated.sh
+++ b/database/scripts/import-validated.sh
@@ -2,6 +2,7 @@
 
 set -u
 
+# shellcheck disable=SC2153 
 database=$DATABASE
 
 echo 'Importing experimentally validated data.' >&2
@@ -26,6 +27,7 @@ tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT INT TERM
 # This data needs to be preprocessed to remove characters that are not
 # UTF-8 and to correct some misspelled terms.
+# shellcheck disable=SC2016
 iconv -c -t UTF-8 "$1" |
 mlr --csv put '
 	$Compound = gssub($Compound,
@@ -84,10 +86,12 @@ cat <<-'SQL' >>"$tmpdir/import.sql"
 SQL
 
 # Create the relationships table between "validated" and "compounds".
+# shellcheck disable=SC1010
 mlr --csv cut -f 'BacMet ID,Compound' then \
 	nest -f Compound --evar ', ' "$tmpdir/data.csv" \
 	>"$tmpdir/validated_compounds.csv"
 
+# shellcheck disable=SC2129
 cat <<-'SQL' >>"$tmpdir/import.sql"
 	CREATE TEMPORARY TABLE validated_compounds_tmp (
 		bacmet_id TEXT NOT NULL,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,4 +6,3 @@ services:
       target: dev
     volumes:
       - ./app/app:/opt/bacmet/app
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       context: app
       target: prod
     ports:
-      - ${APP_HOST:-127.0.0.1}:${APP_PORT:-5000}:${APP_PORT:-5000}
+      - ${APP_HOST:-127.0.0.1}:${APP_PORT:-5000}:5000
     volumes:
       - data:/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       context: app
       target: prod
     ports:
-      - 127.0.0.1:${APP_PORT:-5000}:${APP_PORT:-5000}
+      - ${APP_HOST:-127.0.0.1}:${APP_PORT:-5000}:${APP_PORT:-5000}
     volumes:
       - data:/data
 


### PR DESCRIPTION
This PR closes #41 

This PR introduces the following changes:

1. The `app` Dockerfile...
   1. ... uses the same `WORKDIR` for everything.
   2. ... does not create a `python` group that remains unused.
   3. ... uses a static port (5000) for its internal networking.
2. The `app` entry-point script uses the same static port as the Dockerfile (5000).
3. The `database` Dockerfile gets an optionally configurable `UID` build argument (just like what's available in the `app` Dockerfile since before).
4. The various data import scripts get ShellCheck pragmas to avoid triggering certain test warnings. 
5. The main Docker Compose file will use the value of the `APP_HOST` environment variable instead of `127.0.0.1` when attaching the network on the external host side (there is also `APP_PORT` from before).