### PR TITLE
Add Caddy as reverse proxy

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.4
 FROM python:3.13-alpine AS base
 
+RUN --mount=type=cache,target=/etc/apk/cache \
+    apk add caddy
+
 WORKDIR /opt/bacmet
 
 COPY ./app ./app

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -34,7 +34,7 @@ USER runner
 
 
 # Production build setup
-FROM node:22-alpine3.22 as prod-build
+FROM node:24-alpine as prod-build
 
 WORKDIR /opt/bacmet/frontend
 COPY frontend/bacmet/ ./

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -14,7 +14,11 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 ARG UID=1000
 RUN adduser -D -u "$UID" python
 
-EXPOSE 5000/tcp
+RUN mkdir -m 755 /caddy && chown -R python /caddy
+
+CMD ./start-script.sh
+
+EXPOSE 8080/tcp
 
 
 # Development setup
@@ -23,15 +27,16 @@ FROM base AS dev
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r app/requirements.dev.txt
 
+COPY --chmod=644 caddy/Caddyfile.dev ./Caddyfile
+COPY --chmod=755 scripts/start-script.dev.sh ./start-script.sh
+
 USER python
-CMD flask --app app/main --debug run --host 0.0.0.0 --port 5000
 
 
 # Production setup
 FROM base AS prod
 
+COPY --chmod=644 caddy/Caddyfile ./Caddyfile
 COPY --chmod=755 scripts/start-script.sh ./start-script.sh
 
 USER python
-CMD ./start-script.sh
-

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -6,15 +6,15 @@ RUN --mount=type=cache,target=/etc/apk/cache \
 
 WORKDIR /opt/bacmet
 
-COPY ./app ./app
+COPY app/app ./app
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r app/requirements.txt
 
 ARG UID=1000
-RUN adduser -D -u "$UID" python
+RUN adduser -D -u "$UID" runner
 
-RUN mkdir -m 755 /caddy && chown -R python /caddy
+RUN mkdir -m 755 /caddy && chown -R runner /caddy
 
 CMD ./start-script.sh
 
@@ -27,16 +27,33 @@ FROM base AS dev
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r app/requirements.dev.txt
 
-COPY --chmod=644 caddy/Caddyfile.dev ./Caddyfile
-COPY --chmod=755 scripts/start-script.dev.sh ./start-script.sh
+COPY --chmod=644 app/caddy/Caddyfile.dev ./Caddyfile
+COPY --chmod=755 app/scripts/start-script.dev.sh ./start-script.sh
 
-USER python
+USER runner
+
+
+# Production build setup
+FROM base AS prod-build
+
+RUN --mount=type=cache,target=/etc/apk/cache \
+    apk add nodejs npm
+
+WORKDIR /opt/bacmet/frontend
+COPY frontend/bacmet/ ./
+
+RUN --mount=type=cache,target=/root/.npm \
+	npm ci
+
+RUN npm run build
 
 
 # Production setup
 FROM base AS prod
 
-COPY --chmod=644 caddy/Caddyfile ./Caddyfile
-COPY --chmod=755 scripts/start-script.sh ./start-script.sh
+COPY --from=prod-build /opt/bacmet/frontend/out ./frontend
 
-USER python
+COPY --chmod=644 app/caddy/Caddyfile ./Caddyfile
+COPY --chmod=755 app/scripts/start-script.sh ./start-script.sh
+
+USER runner

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -34,10 +34,7 @@ USER runner
 
 
 # Production build setup
-FROM base AS prod-build
-
-RUN --mount=type=cache,target=/etc/apk/cache \
-    apk add nodejs npm
+FROM node:22-alpine3.22 as prod-build
 
 WORKDIR /opt/bacmet/frontend
 COPY frontend/bacmet/ ./

--- a/app/caddy/Caddyfile
+++ b/app/caddy/Caddyfile
@@ -1,0 +1,1 @@
+# TODO: Write production Caddyfile

--- a/app/caddy/Caddyfile
+++ b/app/caddy/Caddyfile
@@ -1,1 +1,14 @@
-# TODO: Write production Caddyfile
+:8080 {
+	log {
+		output stderr
+		format console
+		level WARN
+	}
+
+	handle /api/* {
+		reverse_proxy app:5000
+	}
+
+	root * ./frontend
+	file_server
+}

--- a/app/caddy/Caddyfile.dev
+++ b/app/caddy/Caddyfile.dev
@@ -1,0 +1,13 @@
+:8080 {
+	log {
+		output stderr
+		format console
+		level INFO
+	}
+
+	handle /api/* {
+		reverse_proxy app:5000
+	}
+
+	reverse_proxy frontend:3000
+}

--- a/app/scripts/start-script.dev.sh
+++ b/app/scripts/start-script.dev.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
-XDG_DATA_HOME=/caddy caddy start --config ./Caddyfile
-exec flask --app app/main --debug run --host 0.0.0.0 --port 5000
+XDG_DATA_HOME=/caddy caddy run --config ./Caddyfile &
+flask --app app/main --debug run --host 0.0.0.0 --port 5000 &
+wait

--- a/app/scripts/start-script.dev.sh
+++ b/app/scripts/start-script.dev.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+XDG_DATA_HOME=/caddy caddy start --config ./Caddyfile
+exec flask --app app/main --debug run --host 0.0.0.0 --port 5000

--- a/app/scripts/start-script.dev.sh
+++ b/app/scripts/start-script.dev.sh
@@ -2,4 +2,5 @@
 
 XDG_DATA_HOME=/caddy caddy run --config ./Caddyfile &
 flask --app app/main --debug run --host 0.0.0.0 --port 5000 &
+
 wait

--- a/app/scripts/start-script.sh
+++ b/app/scripts/start-script.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-exec gunicorn -w "${APP_WORKERS:-4}" app:app -b 0.0.0.0:5000
+XDG_DATA_HOME=/caddy caddy run --config ./Caddyfile &
+gunicorn -w "${APP_WORKERS:-4}" app:app -b 0.0.0.0:5000 &
+
+wait

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -7,24 +7,16 @@ RUN apk add --no-cache \
 ARG UID=1000
 RUN adduser -D -u "$UID" database
 
-RUN mkdir -m 775 /data
-RUN chown database /data
+RUN mkdir -m 755 /data && chown -R database /data
 
-USER database
 WORKDIR /home/database
 
-RUN mkdir scripts
-RUN mkdir sql
-
-COPY --chmod=644 sql/schema.sql sql/
-COPY --chmod=755 scripts/start-script.sh ./
-COPY --chmod=755 scripts/import-validated.sh scripts/
-COPY --chmod=755 scripts/import-validated-compounds.sh scripts/
-COPY --chmod=755 scripts/import-validated-pdb-files.sh scripts/
-COPY --chmod=755 scripts/import-predicted-unique-homologues.sh scripts/
-COPY --chmod=755 scripts/import-predicted-groups.sh scripts/
-COPY --chmod=755 scripts/import-sensitivity-distributions.sh scripts/
+COPY sql/ ./sql/
+COPY scripts/ ./scripts/
+RUN chmod 755 scripts/*.sh
+RUN mv scripts/start-script.sh .
 
 ENV DATABASE=/data/database.db
 
+USER database
 CMD ./start-script.sh

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,7 +10,5 @@ services:
   frontend:
     build:
       context: frontend
-    ports:
-      - ${APP_HOST:-127.0.0.1}:${APP_PORT:-3000}:3000
     volumes:
       - ./frontend/bacmet:/opt/bacmet/frontend

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,6 +9,6 @@ services:
 
   frontend:
     build:
-      context: frontend
+      dockerfile: frontend/Dockerfile
     volumes:
       - ./frontend/bacmet:/opt/bacmet/frontend

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-name: bacmet
-
 services:
   app:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
 
   app:
     build:
-      context: app
+      dockerfile: app/Dockerfile
       target: prod
     ports:
       - ${APP_HOST:-127.0.0.1}:${APP_PORT:-5000}:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,11 @@ services:
       context: app
       target: prod
     ports:
-      - ${APP_HOST:-127.0.0.1}:${APP_PORT:-5000}:5000
+      - ${APP_HOST:-127.0.0.1}:${APP_PORT:-5000}:8080
     volumes:
       - data:/data
+      - caddy:/caddy
 
 volumes:
   data:
+  caddy:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,6 @@
-########################################
-FROM node:22-alpine3.22 AS dev
-ARG FRONTEND_SRC_DIR=/opt/bacmet/frontend
+FROM node:24-alpine AS dev
 
-RUN mkdir -p "$FRONTEND_SRC_DIR"
-WORKDIR "$FRONTEND_SRC_DIR"
+WORKDIR /opt/bacmet/frontend
 
-USER 1000:1000
+USER 1000
 CMD npm ci && npm run dev

--- a/frontend/bacmet/app/search/page.tsx
+++ b/frontend/bacmet/app/search/page.tsx
@@ -141,17 +141,17 @@ const SearchBase = (
       selectedPeptideSequenceLengthMax !== null
     ) {
       const fetchResult = async () => {
-        const url = new URL(`${apiRoot}/search/${selectedDatabase}`);
-        url.search = (new URLSearchParams({
+	const params = new URLSearchParams({
           page: selectedPage || "0",
           location: selectedLocation,
           chemical_class: selectedChemicalClass,
           protein_description: selectedProteinDescription,
           peptide_sequence_length_min: selectedPeptideSequenceLengthMin,
           peptide_sequence_length_max: selectedPeptideSequenceLengthMax,
-        })).toString();
+        });
         try {
-          const resultData = await (await fetch(url.toString())).json();
+	  const response = await fetch(`${apiRoot}/search/${selectedDatabase}?${params}`);
+          const resultData = await response.json();
           setResult({type: selectedDatabase, ...resultData});
         } catch (e) {
           console.warn(e);

--- a/frontend/bacmet/contexts/config.ts
+++ b/frontend/bacmet/contexts/config.ts
@@ -5,7 +5,7 @@ export type Config = {
 }
 
 export const ConfigContext = createContext<Config>({
-    apiRoot: "http://localhost:5000/api",
+    apiRoot: "/api",
 })
 
 export const useConfig = () => {

--- a/frontend/bacmet/package.json
+++ b/frontend/bacmet/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->

This PR closes #74 

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## List of changes made

This PR introduces Caddy as a reverse proxy for both development and production environments.

For production, it adds a build target, `prod-build`, in `app/Dockerfile`, which builds the static site.  The `prod` target then copies the built site and starts Caddy (and the REST API service) to serve it.

## Testing

<!-- Please delete options that are not relevant -->

- A certain branch in other repos is needed
- A rebuild is needed due to new dependencies
- Requires new configuration settings
- Instructions on how to test

The code should work as-is, out of the box, without generating new warnings or errors.  You will notice Caddy logging the traffic that it's handling (in production mode, the log level is set to `WARN`, so it won't actually show each request).

You should test both the development environment:
```
docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
```
... and the production environment:
```
docker compose up --build
```

## Further comments

<!-- Specify questions or related information -->

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any