### PR TITLE
Handle scaling of markdown images

### DIFF
--- a/frontend/bacmet/app/about/page.tsx
+++ b/frontend/bacmet/app/about/page.tsx
@@ -1,8 +1,8 @@
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
-import ReactMarkdown from "react-markdown";
 import React from "react";
+import Markdown from "../components/markdown-util";
 
 export default function About() {
   const filePath = path.join(process.cwd(), "public/markdown-content/about.md");
@@ -11,18 +11,7 @@ export default function About() {
 
   return (
     <div className="text-center pt-3">
-      <ReactMarkdown
-        components={{
-          img: ({ node, ...props }) => (
-            <img
-              {...props}
-              className="img-fluid"
-            />
-          ),
-        }}
-      >
-        {content}
-      </ReactMarkdown>
+      <Markdown>{content}</Markdown>
     </div>
   );
 }

--- a/frontend/bacmet/app/about/page.tsx
+++ b/frontend/bacmet/app/about/page.tsx
@@ -11,7 +11,18 @@ export default function About() {
 
   return (
     <div className="text-center pt-3">
-      <ReactMarkdown>{content}</ReactMarkdown>
+      <ReactMarkdown
+        components={{
+          img: ({ node, ...props }) => (
+            <img
+              {...props}
+              className="img-fluid"
+            />
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
     </div>
   );
 }

--- a/frontend/bacmet/app/components/markdown-util.tsx
+++ b/frontend/bacmet/app/components/markdown-util.tsx
@@ -1,0 +1,15 @@
+import ReactMarkdown from 'react-markdown';
+
+export default function Markdown({ children }: { children: string }) {
+  return (
+    <ReactMarkdown
+      components={{
+        img: ({ node, ...props }) => (
+          <img {...props} className="img-fluid" />
+        ),
+      }}
+    >
+      {children}
+    </ReactMarkdown>
+  );
+} 

--- a/frontend/bacmet/app/contact/page.tsx
+++ b/frontend/bacmet/app/contact/page.tsx
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
 import React from "react";
-import ReactMarkdown from "react-markdown";
+import Markdown from "../components/markdown-util";
 import ContactCard from "../components/contact-card";
 import type { Contact } from "../types";
 
@@ -29,7 +29,7 @@ export default function Contact() {
   return (
     <>
       <div className="text-center pt-3">
-        <ReactMarkdown>{content}</ReactMarkdown>
+        <Markdown>{content}</Markdown>
       </div>
       <div className="row justify-content-center">
         {contacts.map((contact, index) => (

--- a/frontend/bacmet/app/faq/page.tsx
+++ b/frontend/bacmet/app/faq/page.tsx
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
 import React from "react";
-import ReactMarkdown from "react-markdown";
+import Markdown from "../components/markdown-util";
 import Sidebar from "../components/sidebar/sidebar";
 import type { FAQItem } from "../types";
 
@@ -26,7 +26,7 @@ export default function FAQPage() {
   return (
     <>
       <div className="text-center py-3">
-        <ReactMarkdown>{content}</ReactMarkdown>
+        <Markdown>{content}</Markdown>
       </div>
       <div className="row row-gap-3">
         <div className="col-md-4 order-md-last">

--- a/frontend/bacmet/app/layout.tsx
+++ b/frontend/bacmet/app/layout.tsx
@@ -44,18 +44,16 @@ export default function RootLayout({
                 <div>
                   <Link className="navbar-brand text-white me-1" href="/">{brandName}</Link> <i className="bi bi-virus text-white"></i>
                 </div>
-                <div>
-                  <button className="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
-                    aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                    <span className="navbar-toggler-icon"></span>
-                  </button>
-                  <div className="collapse navbar-collapse" id="navbarSupportedContent">
-                    <ul className="navbar-nav mr-auto">
-                      {navigation.map((item, index) => (
-                        <li key={index} className="nav-item me-2"><Link className="nav-link text-white" href={item.href}>{item.label}</Link></li>
-                      ))}
-                    </ul>
-                  </div>
+                <button className="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
+                  aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                  <span className="navbar-toggler-icon"></span>
+                </button>
+                <div className="collapse navbar-collapse" id="navbarSupportedContent">
+                  <ul className="navbar-nav ms-auto">
+                    {navigation.map((item, index) => (
+                      <li key={index} className="nav-item me-2"><Link className="nav-link text-white" href={item.href}>{item.label}</Link></li>
+                    ))}
+                  </ul>
                 </div>
               </div>
             </nav>

--- a/frontend/bacmet/app/page.tsx
+++ b/frontend/bacmet/app/page.tsx
@@ -3,6 +3,7 @@ import path from "path";
 import matter from "gray-matter";
 import ReactMarkdown from "react-markdown";
 import React from "react";
+import Markdown from "./components/markdown-util";
 
 type IndexProps = {
   heroText: string;
@@ -48,7 +49,7 @@ export default function Home() {
         <div className="row gx-5">
           <div className="col-12 col-lg-8 order-1">
             <div className="p-3">
-              <ReactMarkdown>{content}</ReactMarkdown>
+              <Markdown>{content}</Markdown>
             </div>
           </div>
           <div className="col-12 col-lg-4 order-2">


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes https://github.com/NBISweden/bacmet/issues/83

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## List of changes made
- Scale images added with markdown
- Fix issue with hamburger menu in mobile version of website

## Screenshot of the fix
<img width="762" height="1586" alt="image" src="https://github.com/user-attachments/assets/534510f0-5446-4a37-9b10-245ffb305782" />

<img width="762" height="762" alt="image" src="https://github.com/user-attachments/assets/a16a33fb-c522-425f-afe0-df4b4e42b8e5" />

## Testing
Check out this branch and check that the image on the About-page scales when the screen becomes smaller. Also check the hamburger menu when the screen is smaller. 

## Further comments
I have only made the image scale with CSS. This is because the content is supposed to be dynamic and I think that it would be a bit more complicated asking the content creators to upload three different sizes of the same image and incorporating that with `react-markdown`. Instead, for this target group, it would be easier that they upload one image size instead and that they make sure that image is a reasonable size. 

But if anyone is interested in deep diving into how this would be done, feel free! I however felt that it was out of scope for this particular issue. 

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any