### PR TITLE
Quality of life invisible updates

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -17,8 +17,8 @@ WORKDIR /home/bacmet
 # The caddy and data volume mount points.
 RUN install -d -o "$UID" caddy/ data/
 
-# Other important directories that need to be owned by our service user.
-RUN install -d -o "$UID" app/ frontend/
+# The "app" directory.
+RUN install -d -o "$UID" app/
 
 # Install Python dependencies.
 COPY --chmod=444 app/app/requirements.txt app/

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,56 +1,105 @@
 # syntax=docker/dockerfile:1.4
 FROM python:3.13-alpine AS base
 
-RUN --mount=type=cache,target=/etc/apk/cache \
-    apk add caddy
-
-WORKDIR /opt/bacmet
-
-COPY app/app ./app
-
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install -r app/requirements.txt
+# The "base" target only installs dependencies common to both
+# development and production images, sets up a non-root user,
+# and defines the default command.
 
 ARG UID=1000
-RUN adduser -D -u "$UID" runner
 
-RUN mkdir -m 755 /caddy && chown -R runner /caddy
+RUN adduser -D -u "$UID" bacmet
 
+RUN --mount=type=cache,target=/etc/apk/cache \
+	apk add caddy
+
+WORKDIR /home/bacmet
+
+# The caddy and data volume mount points.
+RUN install -d -o "$UID" caddy/ data/
+
+# Other important directories that need to be owned by our service user.
+RUN install -d -o "$UID" app/ frontend/
+
+# Install Python dependencies.
+COPY --chmod=444 app/app/requirements.txt app/
+RUN --mount=type=cache,target=/root/.cache/pip \
+	pip install -r app/requirements.txt
+
+# The start script will be copied here in later build stages.
 CMD ./start-script.sh
 
 EXPOSE 8080/tcp
 
 
-# Development setup
+## Development setup
 FROM base AS dev
 
+# The "dev" target adds development dependencies and configuration.
+# The REST API code is added via a bind mount by the compose file.
+
+ARG UID=1000
+
+# Install developent Python dependencies.
+COPY --chmod=444 app/app/requirements.dev.txt app/
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install -r app/requirements.dev.txt
+	pip install -r app/requirements.dev.txt
 
-COPY --chmod=644 app/caddy/Caddyfile.dev ./Caddyfile
-COPY --chmod=755 app/scripts/start-script.dev.sh ./start-script.sh
+COPY --chown=$UID --chmod=444 app/caddy/Caddyfile.dev ./Caddyfile
+COPY --chown=$UID --chmod=555 app/scripts/start-script.dev.sh ./start-script.sh
 
-USER runner
+USER "$UID"
 
 
-# Production build setup
+## Production build setup
 FROM node:24-alpine as prod-build
 
-WORKDIR /opt/bacmet/frontend
-COPY frontend/bacmet/ ./
+# The "prod-build" target builds the frontend assets.  It does not
+# include code or configuration.
 
-RUN --mount=type=cache,target=/root/.npm \
-	npm ci
+ARG UID=1000
 
-RUN npm run build
+ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN install -d -o "$UID" /tmp/build /tmp/build/.npm
+
+WORKDIR /tmp/build
+
+# Set up the Node build directories so that we can build everything as
+# our service user later.
+RUN --mount=type=cache,target=/tmp/build/.npm \
+    --mount=type=cache,target=/tmp/build/node_modules \
+	chown -R "$UID" /tmp/build/
+
+# Switch to the service user as the rest of the RUN actions shouldn't
+# require root access.
+USER "$UID"
+
+COPY --chown=$UID --chmod=444 frontend/bacmet/package*.json ./
+RUN --mount=type=cache,target=/tmp/build/.npm \
+    --mount=type=cache,target=/tmp/build/node_modules \
+	npm --cache=/tmp/build/.npm ci
+
+COPY --chown=$UID frontend/bacmet/ ./
+RUN --mount=type=cache,target=/tmp/build/.npm \
+    --mount=type=cache,target=/tmp/build/node_modules \
+	npm --cache=/tmp/build/.npm run build
 
 
-# Production setup
+## Production setup
 FROM base AS prod
 
-COPY --from=prod-build /opt/bacmet/frontend/out ./frontend
+# The "prod" target adds REST API code, production configuration, and
+# copies in the built frontend assets.
 
-COPY --chmod=644 app/caddy/Caddyfile ./Caddyfile
-COPY --chmod=755 app/scripts/start-script.sh ./start-script.sh
+ARG UID=1000
 
-USER runner
+# Copy the static content from the previous build step.
+COPY --chown=$UID --from=prod-build /tmp/build/out ./frontend/
+
+COPY --chown=$UID --chmod=444 app/caddy/Caddyfile ./Caddyfile
+COPY --chown=$UID --chmod=555 app/scripts/start-script.sh ./start-script.sh
+
+# Copy the REST API code last to maximize use of Docker layer caching.
+COPY --chown=$UID app/app ./app/
+
+USER "$UID"

--- a/app/app/database.py
+++ b/app/app/database.py
@@ -6,7 +6,7 @@ import os
 
 Base = automap_base()
 engine = create_engine(
-    os.getenv("APP_DATABASE_CONFIG", "sqlite:////data/database.db")
+    os.getenv("APP_DATABASE_CONFIG", "sqlite:///data/database.db")
 )
 db_session = scoped_session(
     sessionmaker(

--- a/app/app/database.py
+++ b/app/app/database.py
@@ -6,7 +6,7 @@ import os
 
 Base = automap_base()
 engine = create_engine(
-    os.getenv("APP_DATABASE_CONFIG", "sqlite:///data/database.db")
+    os.getenv("APP_DATABASE_CONFIG", "sqlite:////home/bacmet/data/database.db")
 )
 db_session = scoped_session(
     sessionmaker(

--- a/app/app/main.py
+++ b/app/app/main.py
@@ -84,6 +84,12 @@ def pagination_for(endpoint: str, page: int, last_page: int, args: dict, pages_t
     ]
 
 
+@app.route('/api/health-check')
+@cross_origin()
+def health_check():
+    return jsonify({"status": "ok"}), 200
+
+
 @app.route('/api/search/predicted')
 @cross_origin()
 def predicted_search():

--- a/app/scripts/start-script.dev.sh
+++ b/app/scripts/start-script.dev.sh
@@ -1,6 +1,13 @@
-#!/bin/sh
+#!/bin/sh -
 
-caddy run --config ./Caddyfile &
-flask --app app/main --debug run --host 0.0.0.0 --port 5000 &
+set -u
 
-wait
+export XDG_CONFIG_HOME="$HOME/caddy/config"
+export XDG_DATA_HOME="$HOME/caddy/data"
+
+# Create the above directories if they don't exist.
+install -d "$XDG_CONFIG_HOME"
+install -d "$XDG_DATA_HOME"
+
+caddy start --config ./Caddyfile
+exec flask --app app/main --debug run --host 0.0.0.0 --port 5000

--- a/app/scripts/start-script.dev.sh
+++ b/app/scripts/start-script.dev.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-XDG_DATA_HOME=/caddy caddy run --config ./Caddyfile &
+caddy run --config ./Caddyfile &
 flask --app app/main --debug run --host 0.0.0.0 --port 5000 &
 
 wait

--- a/app/scripts/start-script.sh
+++ b/app/scripts/start-script.sh
@@ -1,6 +1,13 @@
-#!/bin/sh
+#!/bin/sh -
 
-caddy run --config ./Caddyfile &
-gunicorn -w "${APP_WORKERS:-4}" app:app -b 0.0.0.0:5000 &
+set -u
 
-wait
+export XDG_CONFIG_HOME="$HOME/caddy/config"
+export XDG_DATA_HOME="$HOME/caddy/data"
+
+# Create the above directories if they don't exist.
+install -d "$XDG_CONFIG_HOME"
+install -d "$XDG_DATA_HOME"
+
+caddy start --config ./Caddyfile
+exec gunicorn -w "${APP_WORKERS:-4}" app:app -b 0.0.0.0:5000

--- a/app/scripts/start-script.sh
+++ b/app/scripts/start-script.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-XDG_DATA_HOME=/caddy caddy run --config ./Caddyfile &
+caddy run --config ./Caddyfile &
 gunicorn -w "${APP_WORKERS:-4}" app:app -b 0.0.0.0:5000 &
 
 wait

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -5,18 +5,20 @@ RUN apk add --no-cache \
 	miller~6
 
 ARG UID=1000
-RUN adduser -D -u "$UID" database
+RUN adduser -D -u "$UID" bacmet
 
-RUN mkdir -m 755 /data && chown -R database /data
+USER "$UID"
 
-WORKDIR /home/database
+WORKDIR /home/bacmet
 
-COPY sql/ ./sql/
-COPY scripts/ ./scripts/
+# Data volume mount point.
+RUN install -d -o "$UID" data/
+
+COPY --chown=$UID sql/ ./sql/
+COPY --chown=$UID scripts/ ./scripts/
 RUN chmod 755 scripts/*.sh
 RUN mv scripts/start-script.sh .
 
-ENV DATABASE=/data/database.db
+ENV DATABASE=/home/bacmet/data/database.db
 
-USER database
 CMD ./start-script.sh

--- a/database/scripts/start-script.sh
+++ b/database/scripts/start-script.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/sh -
+
+set -u
 
 PATH=$HOME/scripts:$PATH
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,9 +4,18 @@ services:
       target: dev
     volumes:
       - ./app/app:/opt/bacmet/app
+    depends_on:
+      frontend:
+        condition: service_healthy
 
   frontend:
     build:
       dockerfile: frontend/Dockerfile
     volumes:
       - ./frontend/bacmet:/opt/bacmet/frontend
+    healthcheck:
+      test: [ "CMD", "wget", "--tries=1", "--spider", "--quiet", "http://frontend:3000/health-check" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,5 @@
+name: bacmet-dev
+
 services:
   app:
     build:
@@ -19,3 +21,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+
+volumes:
+  data:
+    external: true
+    name: bacmet_data

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,7 @@ services:
     build:
       target: dev
     volumes:
-      - ./app/app:/opt/bacmet/app
+      - ./app/app:/home/bacmet/app
     depends_on:
       frontend:
         condition: service_healthy
@@ -14,7 +14,7 @@ services:
     build:
       dockerfile: frontend/Dockerfile
     volumes:
-      - ./frontend/bacmet:/opt/bacmet/frontend
+      - ./frontend/bacmet:/home/bacmet/frontend
     healthcheck:
       test: [ "CMD", "wget", "--tries=1", "--spider", "--quiet", "http://frontend:3000/health-check" ]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,13 @@ services:
     build:
       dockerfile: app/Dockerfile
       target: prod
+    environment:
+      APP_DATABASE_CONFIG: "sqlite:////opt/bacmet/data/database.db"
     ports:
       - ${APP_HOST:-127.0.0.1}:${APP_PORT:-5000}:8080
     volumes:
-      - data:/data
-      - caddy:/caddy
+      - data:/opt/bacmet/data
+      - caddy:/opt/bacmet/.local/share/caddy
     healthcheck:
       test: [ "CMD", "wget", "--tries=1", "--spider", "--quiet", "http://app:5000/api/health-check" ]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - DATABASE_REINIT
     volumes:
-      - data:/data
+      - data:/home/bacmet/data
       - ./data-import:/data-import:ro
     profiles: ["load-data"]
 
@@ -15,13 +15,11 @@ services:
     build:
       dockerfile: app/Dockerfile
       target: prod
-    environment:
-      APP_DATABASE_CONFIG: "sqlite:////opt/bacmet/data/database.db"
     ports:
       - ${APP_HOST:-127.0.0.1}:${APP_PORT:-5000}:8080
     volumes:
-      - data:/opt/bacmet/data
-      - caddy:/opt/bacmet/.local/share/caddy
+      - data:/home/bacmet/data
+      - caddy:/home/bacmet/caddy
     healthcheck:
       test: [ "CMD", "wget", "--tries=1", "--spider", "--quiet", "http://app:5000/api/health-check" ]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,12 @@ services:
     volumes:
       - data:/data
       - caddy:/caddy
+    healthcheck:
+      test: [ "CMD", "wget", "--tries=1", "--spider", "--quiet", "http://app:5000/api/health-check" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
 
 volumes:
   data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:24-alpine AS dev
 
-WORKDIR /opt/bacmet/frontend
+ARG UID=1000
+ENV NEXT_TELEMETRY_DISABLED 1
 
-USER 1000
+WORKDIR /home/bacmet/frontend
+
+USER $UID
 CMD npm ci && npm run dev

--- a/frontend/bacmet/app/health-check/route.ts
+++ b/frontend/bacmet/app/health-check/route.ts
@@ -1,0 +1,5 @@
+export const dynamic = 'force-static'
+
+export async function GET() {
+	  return Response.json({ status: 'ok' })
+}


### PR DESCRIPTION
This PR reorganises the Docker setup of the project in the following ways:

The Dockerfiles:

* Reordering of actions to try to maximise Docker's layer caching.
* Delegating actions to the service user (UID 1000) when root is not actually needed.
* Ensure that the correct ownership and permissions are set on files.
* Using cache mounts for actions that benefit from cache reuse, such as running `apk add`, `npm ci`, and `pip install`.
* Move all serviceable parts (code, data, mounted volumes, etc.) into the service user's home directory, `/home/backmet`.

The Docker Compose files:

* The containers and volumes set up by the development environment, in `docker-compose.dev.yml`, are given a new project name (`bacmet-dev`). This ensures that the Docker images `backmet-app` and `backmet-dev-app` are not confused. Also, this separates the `bacmet_caddy` volume from the `bacmet-dev_caddy` volume.  The development environment still uses the production environment's `bacmet_data` volume (for the database).
* Introduce health checks that run regularly, ensuring that Docker and any external monitoring software are able to assess the health of the services.
* Introduce dependency between the two containers in the development setup, ensuring that the frontend isn't served before the backend is up and running (and "healthy").

Code:

* Endpoints to support the Docker Compose health checks were added:
   * For the frontend: `/health-check`
   * For the backend: `/api/health-check`