### PR TITLE
fix: improve nav experience in prod

### DIFF
--- a/app/caddy/Caddyfile
+++ b/app/caddy/Caddyfile
@@ -9,8 +9,6 @@
 		reverse_proxy app:5000
 	}
 
-	rewrite /search/entry/* /search/entry/
-
 	root * ./frontend
 	file_server
 }

--- a/app/caddy/Caddyfile.dev
+++ b/app/caddy/Caddyfile.dev
@@ -9,7 +9,5 @@
 		reverse_proxy app:5000
 	}
 
-	rewrite /search/entry/* /search/entry/
-
 	reverse_proxy frontend:3000
 }

--- a/frontend/bacmet/app/search/entry/client-render.tsx
+++ b/frontend/bacmet/app/search/entry/client-render.tsx
@@ -1,6 +1,0 @@
-import React from "react"
-
-
-export default function ClientRender({children}: {children: React.ReactNode}) {
-  return children
-}

--- a/frontend/bacmet/app/search/entry/page.tsx
+++ b/frontend/bacmet/app/search/entry/page.tsx
@@ -2,12 +2,11 @@
 import { useConfig } from "../../../contexts/config";
 import { Suspense, useState, useMemo, ReactNode, useEffect, useCallback, useId, ChangeEventHandler } from "react";
 import {PredictedResult, ErrorResult, Link, Validated, Predicted, MultiValueField} from "../types";
-import { useSearchParams, usePathname, useRouter } from "next/navigation";
-import dynamic from 'next/dynamic'
+import { useSearchParams } from "next/navigation";
 import ValidatedEntry from "../components/validated-entry";
 import { Pagination } from "../components/pagination";
+import {navigateInPage} from "../../utils";
 
-const ClientRender = dynamic(() => import('./client-render'), { ssr: false })
 
 const MultiSelectField = ({field, value, onChange}: {field: MultiValueField<unknown>, value: unknown[], onChange: (value: unknown[]) => void}) => {
   const fieldId = useId();
@@ -96,15 +95,10 @@ const EmptyValidatedEntry: Validated = {
 function EntryViewWithParams() {
   const {apiRoot} = useConfig();
   const searchParams = useSearchParams();
-  const pathname = usePathname();
-  const match = pathname.match(/^\/search\/entry\/(.*?)(\/.*)?$/);
   const [validated, setValidated] = useState<Validated | null>(null);
-  
-  const entryIdFromPath = match && match[1];
-  const entryIdFromSearchParams = searchParams.get("entry_id");
-  const entryId = entryIdFromPath || entryIdFromSearchParams;
 
-  const router = useRouter();
+  const entryId = searchParams.get("entry_id");
+
   const [predictedResult, setPredictedResult] = useState<PredictedResult | ErrorResult | undefined>(undefined);
   const predictedPage = searchParams.get("page") || "0";
 
@@ -148,8 +142,10 @@ function EntryViewWithParams() {
   const handlePageNavigation = useCallback((page: Link) => {
       const url = new URL(page.href);
       const pageNumber = url.searchParams.get("page") || "0";
-      router.push(pathname + `?page=${pageNumber}`);
-  }, [pathname, router])
+      if (entryId) {
+        navigateInPage({entry_id: entryId, page: pageNumber});
+      }
+  }, [entryId])
 
 
   const allPages = (predictedResult && "_links" in predictedResult ? predictedResult._links : []);
@@ -238,7 +234,7 @@ export default function EntryPage() {
   return (
     <div className="row justify-content-center pt-3 pb-3">
       <Suspense fallback={<ValidatedEntry entry={EmptyValidatedEntry}/>}>
-        <ClientRender><EntryViewWithParams /></ClientRender>
+        <EntryViewWithParams />
       </Suspense>
     </div>
   );

--- a/frontend/bacmet/app/search/page.tsx
+++ b/frontend/bacmet/app/search/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import {useCallback, useEffect, useState, FormEventHandler, Suspense} from "react";
 import {useConfig} from "../../contexts/config";
-import {useSearchParams, useRouter, usePathname} from "next/navigation";
+import {useSearchParams, usePathname} from "next/navigation";
 import {SearchParams, ValidatedResult, ErrorResult, Field, Link} from "./types";
 import {FieldSet} from "./components/fieldset";
 import {Pagination} from "./components/pagination";
@@ -10,6 +10,7 @@ import {SelectField} from "./components/select-field";
 import {TextField} from "./components/text-field";
 import {default as NextLink} from 'next/link'
 import ValidatedEntry from "./components/validated-entry";
+import {navigateInPage} from "../utils";
 
 const SearchBase = (
   {values}: {
@@ -93,7 +94,6 @@ const SearchBase = (
     values: [],
   }
 
-  const router = useRouter()
   const pathname = usePathname()
 
   useEffect(() => {
@@ -158,8 +158,8 @@ const SearchBase = (
   const handlePageNavigation = useCallback((page: Link) => {
       const url = new URL(page.href);
       const params = url.searchParams;
-      router.push(pathname + '?' + params.toString());
-  }, [pathname, router])
+      navigateInPage(params);
+  }, [])
 
   const handleSubmit: FormEventHandler = useCallback((event) => {
     event.preventDefault();
@@ -178,12 +178,8 @@ const SearchBase = (
         acc[fieldName] = `${value}`;
         return acc;
     }, {});
-    const params = new URLSearchParams(values);
-    router.push(pathname + '?' + params.toString());
-  }, [
-    router,
-    pathname,
-  ]);
+    navigateInPage(values);
+  }, []);
   const allPages = (result && "_links" in result ? result._links : []);
   const pageCount = (result && "_meta" in result ? result._meta.totalPages : undefined);
   const currentPageHref = allPages.filter(l => l.rel === "self")[0]?.href;
@@ -234,7 +230,7 @@ const SearchBase = (
                             <td>
                               <ValidatedEntry entry={item}/>
                             </td>
-                            <td><NextLink href={`/search/entry/${item.bacmet_id}`}>View entries</NextLink></td>
+                            <td><NextLink href={`/search/entry/?entry_id=${item.bacmet_id}`}>View entries</NextLink></td>
                           </tr>
                         ))}
                       </tbody>

--- a/frontend/bacmet/app/utils.ts
+++ b/frontend/bacmet/app/utils.ts
@@ -1,0 +1,9 @@
+export function navigateInPage(params: Record<string, string | string[]> | URLSearchParams) {
+    if (params instanceof URLSearchParams) {
+        window.history.pushState(null, "", `?${params.toString()}`);
+    } else {
+        const init = Object.entries(params).flatMap(([key, value]) => (Array.isArray(value) ? value.map(v => [key, v]) : [[key, value]]));
+        const searchParams = new URLSearchParams(init);
+        window.history.pushState(null, "", `?${searchParams.toString()}`);
+    }
+}


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->
## Related issue(s) and PR(s)

This PR tries to fix an issue in `prod` where the page is reloaded when doing certain navigation operations withing the `search` and `search/entry` routes. This cause the page to jump around an reload data unnecessarily which can be annoying to the user.

The problem is caused by the static build setup not supporting client side navigation for that configuration option so I try to fix it by using the browser native navigation functionality.

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change

<!-- Please delete options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

## List of changes made

- Removed caddy rewrites and use url search params instead
- Use browser native navigation instead of nextjs built in


## Testing

- The site should behave as originally in development mode
- When running production mode:
  - go to http://localhost:5000/search/
  - make a selection and do a search
  - navigate the pagination (expect the page not to reload but only update the table data)
  - navigate to one entry using the link
  - within the entry use the pagination (expect the page not to reload but only update the table data)

## Further comments

<!-- Specify questions or related information -->

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any