### PR TITLE
Free text search genes/biocides/metals/chemical class

### DIFF
--- a/app/app/main.py
+++ b/app/app/main.py
@@ -172,6 +172,8 @@ def validated_search():
         request.args.get("peptide_sequence_length_max")
     ))
     gene_name = request.args.get("gene_name")
+    free_text = request.args.get("free_text")
+
     page = max(0, int(request.args.get("page", "0")))
     page_size = 100
 
@@ -181,6 +183,7 @@ def validated_search():
         protein_description=protein_description,
         peptide_sequence_length_range=peptide_sequence_length_range,
         gene_name=gene_name,
+        free_text=free_text,
         pagination=(page, page_size)
     )
 

--- a/app/app/search.py
+++ b/app/app/search.py
@@ -23,7 +23,8 @@ def apply_search_filters(
     location: Optional[LocationOption],
     protein_description: Optional[str],
     peptide_sequence_length_range: Optional[OpenRange],
-    gene_name: Optional[str] = None
+    gene_name: Optional[str] = None,
+    free_text: Optional[str] = None
 ):
     if chemical_class:
         chemical_class_type, chemical_class_name = chemical_class
@@ -55,6 +56,13 @@ def apply_search_filters(
     if gene_name:
         stmt = stmt.filter(
             Validated.gene_name == gene_name
+        )
+    if free_text:
+        search_pattern = f"%{free_text}%"
+        stmt = stmt.filter(
+            (Validated.gene_name.ilike(search_pattern)) |
+            (Validated.compounds.any(Compounds.compound_name.ilike(search_pattern))) |
+            (Validated.compounds.any(Compounds.chemical_class.ilike(search_pattern)))
         )
     return stmt
 
@@ -89,7 +97,8 @@ def find_in_validated(
     protein_description: Optional[str],
     peptide_sequence_length_range: Optional[OpenRange],
     gene_name: Optional[str],
-    pagination: Tuple[int, int]
+    pagination: Tuple[int, int],
+    free_text: Optional[str] = None
 ) -> Tuple[list[Validated], int]:
     stmt = apply_search_filters(
         select(Validated).options(
@@ -99,7 +108,8 @@ def find_in_validated(
         location,
         protein_description,
         peptide_sequence_length_range,
-        gene_name
+        gene_name,
+        free_text
     )
     with db_session() as session:
         items = session.execute(

--- a/frontend/bacmet/app/components/quick-search-form.tsx
+++ b/frontend/bacmet/app/components/quick-search-form.tsx
@@ -23,7 +23,7 @@ export default function QuickSearchForm() {
         type="text"
         name="free_text"
         id="quick-search-input"
-        placeholder="ex. gene name, compound name, chemical class"
+        placeholder="gene name, compound name, chemical class"
       />
       <button className="btn btn-primary mt-2" type="submit">
         Search

--- a/frontend/bacmet/app/components/quick-search-form.tsx
+++ b/frontend/bacmet/app/components/quick-search-form.tsx
@@ -1,0 +1,33 @@
+'use client'
+import React, { useRef } from "react";
+import { useRouter } from "next/navigation";
+
+export default function QuickSearchForm() {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
+
+  function handleQuickSearchSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const value = inputRef.current?.value.trim();
+    if (value) {
+      router.push(`/search?free_text=${encodeURIComponent(value)}`);
+    }
+  }
+
+  return (
+    <form className="mb-4" onSubmit={handleQuickSearchSubmit}>
+      <label className="form-label" htmlFor="quick-search-input">Free text search:</label>
+      <input
+        ref={inputRef}
+        className="form-control"
+        type="text"
+        name="free_text"
+        id="quick-search-input"
+        placeholder="ex. gene name, compound name, chemical class"
+      />
+      <button className="btn btn-primary mt-2" type="submit">
+        Search
+      </button>
+    </form>
+  );
+}

--- a/frontend/bacmet/app/page.tsx
+++ b/frontend/bacmet/app/page.tsx
@@ -4,6 +4,7 @@ import matter from "gray-matter";
 import ReactMarkdown from "react-markdown";
 import React from "react";
 import Markdown from "./components/markdown-util";
+import QuickSearchForm from "./components/quick-search-form";
 
 type IndexProps = {
   heroText: string;
@@ -55,6 +56,7 @@ export default function Home() {
           <div className="col-12 col-lg-4 order-2">
             <div className="p-3 border bg-white">
               <ReactMarkdown>{indexProps.quickSearchDescription}</ReactMarkdown>
+              <QuickSearchForm />
             </div>
           </div>
         </div>

--- a/frontend/bacmet/app/search/page.tsx
+++ b/frontend/bacmet/app/search/page.tsx
@@ -27,6 +27,7 @@ const SearchBase = (
     selectedProteinDescription,
     selectedPeptideSequenceLengthMin,
     selectedPeptideSequenceLengthMax,
+    selectedFreeText
   ] = [
     "page",
     "location",
@@ -34,6 +35,7 @@ const SearchBase = (
     "protein_description",
     "peptide_sequence_length_min",
     "peptide_sequence_length_max",
+    "free_text"
   ].map(key => values[key] === undefined ? null : values[key]);
   const [params, setParams] = useState<SearchParams>({
     chemicalClasses: [],
@@ -93,6 +95,13 @@ const SearchBase = (
     placeholder: "2000",
     values: [],
   }
+  const freeText: Field = {
+    label: "Free text search",
+    name: "free_text",
+    value: selectedFreeText || undefined,
+    placeholder: "example: gene name, compound name, chemical class",
+    values: []
+  }
 
   useEffect(() => {
     const fetchData = async () => {
@@ -120,7 +129,8 @@ const SearchBase = (
       selectedChemicalClass !== null &&
       selectedProteinDescription !== null &&
       selectedPeptideSequenceLengthMin !== null &&
-      selectedPeptideSequenceLengthMax !== null
+      selectedPeptideSequenceLengthMax !== null &&
+      selectedFreeText !== null
     ) {
       const fetchResult = async () => {
       const params = new URLSearchParams({
@@ -130,6 +140,7 @@ const SearchBase = (
           protein_description: selectedProteinDescription,
           peptide_sequence_length_min: selectedPeptideSequenceLengthMin,
           peptide_sequence_length_max: selectedPeptideSequenceLengthMax,
+          free_text: selectedFreeText
         });
         try {
 	  const response = await fetch(`${apiRoot}/search/validated?${params}`);
@@ -149,8 +160,9 @@ const SearchBase = (
     selectedProteinDescription,
     selectedPeptideSequenceLengthMin,
     selectedPeptideSequenceLengthMax,
+    selectedFreeText,
     setResult,
-    apiRoot
+    apiRoot,
   ]);
 
   const handlePageNavigation = useCallback((page: Link) => {
@@ -170,6 +182,7 @@ const SearchBase = (
       "protein_description",
       "peptide_sequence_length_min",
       "peptide_sequence_length_max",
+      "free_text"
     ].reduce<{[x: string]: string}>((acc, fieldName) => {
         const selectedTarget = target[fieldName];
         const value = selectedTarget.type === "checkbox" ? !!selectedTarget.checked : selectedTarget.value;
@@ -191,6 +204,7 @@ const SearchBase = (
           irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
         <form onSubmit={handleSubmit}>
           <input type="hidden" name="page" value="0" />
+          <FieldSet><TextField field={freeText}/></FieldSet>
           <FieldSet><SelectField field={chemicalClassOrCompound}/></FieldSet>
           <FieldSet><TextField field={proteinDescription}/></FieldSet>
           <FieldSet>
@@ -260,6 +274,7 @@ const SearchWithSearchParams = () => {
     "protein_description",
     "peptide_sequence_length_min",
     "peptide_sequence_length_max",
+    "free_text"
   ].reduce<{[x: string]: string | null}>((acc, key) => {
     acc[key] = searchParams.get(key)
     return acc;

--- a/frontend/bacmet/app/search/page.tsx
+++ b/frontend/bacmet/app/search/page.tsx
@@ -99,7 +99,7 @@ const SearchBase = (
     label: "Free text search",
     name: "free_text",
     value: selectedFreeText || undefined,
-    placeholder: "example: gene name, compound name, chemical class",
+    placeholder: "gene name, compound name, chemical class",
     values: []
   }
 
@@ -124,34 +124,27 @@ const SearchBase = (
   }, [apiRoot, setParams]);
 
   useEffect(() => {
-    if (
-      selectedLocation !== null &&
-      selectedChemicalClass !== null &&
-      selectedProteinDescription !== null &&
-      selectedPeptideSequenceLengthMin !== null &&
-      selectedPeptideSequenceLengthMax !== null &&
-      selectedFreeText !== null
-    ) {
+    const params = new URLSearchParams();
+    if (selectedPage) params.append("page", selectedPage || "0");
+    if (selectedLocation) params.append("location", selectedLocation);
+    if (selectedChemicalClass) params.append("chemical_class", selectedChemicalClass);
+    if (selectedProteinDescription) params.append("protein_description", selectedProteinDescription);
+    if (selectedPeptideSequenceLengthMin) params.append("peptide_sequence_length_min", selectedPeptideSequenceLengthMin);
+    if (selectedPeptideSequenceLengthMax) params.append("peptide_sequence_length_max", selectedPeptideSequenceLengthMax);
+    if (selectedFreeText) params.append("free_text", selectedFreeText);
+
+    if (params.size > 0) {
       const fetchResult = async () => {
-      const params = new URLSearchParams({
-          page: selectedPage || "0",
-          location: selectedLocation,
-          chemical_class: selectedChemicalClass,
-          protein_description: selectedProteinDescription,
-          peptide_sequence_length_min: selectedPeptideSequenceLengthMin,
-          peptide_sequence_length_max: selectedPeptideSequenceLengthMax,
-          free_text: selectedFreeText
-        });
         try {
-	  const response = await fetch(`${apiRoot}/search/validated?${params}`);
+          const response = await fetch(`${apiRoot}/search/validated?${params.toString()}`);
           const resultData = await response.json();
-          setResult({type: "validated", ...resultData});
+          setResult({ type: "validated", ...resultData });
         } catch (e) {
           console.warn(e);
-          setResult({type: "error", error: `Failed to get data from the backend: ${e}`})
+          setResult({ type: "error", error: `Failed to get data from the backend: ${e}` });
         }
-      }
-      fetchResult()
+      };
+      fetchResult();
     }
   }, [
     selectedPage,

--- a/frontend/bacmet/public/markdown-content/index.md
+++ b/frontend/bacmet/public/markdown-content/index.md
@@ -3,7 +3,7 @@ heroText: BacMet is an easy-to-use bioinformatics resource of antibacterial bioc
 heroImage: /img/hero-image.jpg
 quickSearchDescription: |
   ## Quick search
-  You can search the BacMet database using any full term, including for example gene names (e.g. copA), name of biocides (e.g. Triclosan), metals (e.g. Arsenic) or chemical classes (e.g. Acridine). You will redirected to the search page.
+  You can search the BacMet database using any full term, including for example gene names (e.g. copA), name of biocides (e.g. Triclosan), metals (e.g. Arsenic) or chemical classes (ex. Acridine). You will be redirected to the search page.
 ---
 
 # Bacmet Database

--- a/frontend/bacmet/public/markdown-content/index.md
+++ b/frontend/bacmet/public/markdown-content/index.md
@@ -3,7 +3,7 @@ heroText: BacMet is an easy-to-use bioinformatics resource of antibacterial bioc
 heroImage: /img/hero-image.jpg
 quickSearchDescription: |
   ## Quick search
-  Lorem ipsum dolor sit, amet consectetur adipisicing elit. Minima quibusdam quae vel consequuntur quis.
+  You can search the BacMet database using any full term, including for example gene names (e.g. copA), name of biocides (e.g. Triclosan), metals (e.g. Arsenic) or chemical classes (e.g. Acridine). You will redirected to the search page.
 ---
 
 # Bacmet Database


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR closes https://github.com/NBISweden/bacmet/issues/32

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## List of changes made
- Added `free_text` as a filter for the search-functionality in backend. 
- Updated code for `Quick search`-box on the `index`-page so that it redirects to the `search` page and brings the entered value as a parameter. 
- Updated the `useEffect` in the search-page in order to use the url-parameter from the `index`-page. 

## Screenshot of the fix
<img width="701" height="833" alt="image" src="https://github.com/user-attachments/assets/47fcb13a-8fd5-4f38-b029-a2da45864f38" />

## Testing
Check out this branch. Enter a gene name, biocide name, metal name or chemical class in the Quick search-box and click search. See that you're redirected to the search page and that you see the relevant result based on your search term. 

Change the search params (remove the free text search term for example) when you're on the search page and see that the url and search result updates accordingly. 

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any