### PR TITLE
Show values when hovering bubbles and adjust bubble sizes

### DIFF
--- a/frontend/bacmet/app/sensitivity-distributions/[primaryType]/bubble-plot.tsx
+++ b/frontend/bacmet/app/sensitivity-distributions/[primaryType]/bubble-plot.tsx
@@ -8,6 +8,7 @@ export type BubblePlotProps = {
     verticalLabels: string[];
     horizontalLabels: string[];
     values: number[][];
+    formatValue?: (v: number) => string;
 }
 
 export default function BubblePlot(
@@ -17,7 +18,8 @@ export default function BubblePlot(
     xLabel,
     verticalLabels,
     horizontalLabels,
-    values
+    values,
+    formatValue
   }: BubblePlotProps
 ) {
   const xVals = horizontalLabels.map((_, i) => i);
@@ -35,6 +37,7 @@ export default function BubblePlot(
           x: values.flatMap(subvals => subvals.map((_, xi) => xi)),
           y: values.flatMap((subvals, yi) => subvals.map(() => yi)),
           mode: 'markers',
+          text: formatValue ? flatValues.map(formatValue) : undefined,
           marker: {
             size: markerSizes,
           }

--- a/frontend/bacmet/app/sensitivity-distributions/[primaryType]/bubble-plot.tsx
+++ b/frontend/bacmet/app/sensitivity-distributions/[primaryType]/bubble-plot.tsx
@@ -26,7 +26,7 @@ export default function BubblePlot(
   const yVals = verticalLabels.map((_, i) => i);
   const flatValues = values.flatMap(subvals => subvals.map(v => v))
   const maxVal = Math.max(...flatValues, 1);
-  const markerSizes = flatValues.map(v => 40 * v / maxVal);
+  const markerSizes = flatValues.map(v => 40 * Math.sqrt(v / maxVal));
   const maxVerticalLabels = Math.max(...verticalLabels.map(l => l.length), 10);
   const rowSize = 60;
   return (

--- a/frontend/bacmet/app/sensitivity-distributions/[primaryType]/sensitivity-distributions-view.tsx
+++ b/frontend/bacmet/app/sensitivity-distributions/[primaryType]/sensitivity-distributions-view.tsx
@@ -161,6 +161,7 @@ export function SensitivitDistributionsView({primaryType}: {primaryType: string}
             yLabel={yLabel}
             horizontalLabels={horizontalLabels}
             verticalLabels={verticalLabels}
+            formatValue={v => `Count: ${v}`}
           />
         </div>
       ) : <div className="col-sm-12 col-md-9 col-lg-7">Make a selection to view bubble plot</div>}


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->
## Related issue(s) and PR(s)

This PR closes #95 and closes #94

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change

<!-- Please delete options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

## List of changes made

- Show the value in the tooltip of the bubble plot
- Set the size of a bubble to depend on `sqrt(value)` in order to make the area of the bubble represent the value rather than the radius

## Screenshot of the fix

<img width="2960" height="1984" alt="Screen Shot 2025-09-10 at 13 49 56" src="https://github.com/user-attachments/assets/2cfc5523-61b6-44fb-a2ee-6b78da83dd07" />


## Testing

- go to: http://localhost:5000/sensitivity-distributions/species/ and http://localhost:5000/sensitivity-distributions/biocide/
- make your selection
- make sure the value is shown in the tooltip when hovering bubbles
- make sure the bubble sizes appear to have areas representing the values

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any