### PR TITLE
Ensure that whitespace is trimmed from input files during import

### DIFF
--- a/database/scripts/import-predicted-groups.sh
+++ b/database/scripts/import-predicted-groups.sh
@@ -29,7 +29,13 @@ trap 'rm -rf "$tmpdir"' EXIT INT TERM
 echo 'Extracting Zip archive...' >&2
 unzip -q -d "$tmpdir" "$data_zip_archive"
 
-echo 'Loading files into database...' >&2
+echo 'Preprocessing CSV files...' >&2
+printf '%s\0' "$tmpdir"/*.csv |
+xargs -0 -P "$(nproc)" -n 50 sh -c '
+	mlr -I --csv clean-whitespace "$@"
+	' sh
+
+echo 'Loading CSV files into database...' >&2
 
 cat <<-'SQL' >"$tmpdir/import.sql"
 	.mode csv

--- a/database/scripts/import-predicted-unique-homologues.sh
+++ b/database/scripts/import-predicted-unique-homologues.sh
@@ -29,10 +29,19 @@ trap 'rm -rf "$tmpdir"' EXIT INT TERM
 echo 'Extracting Zip archive...' >&2
 unzip -q -d "$tmpdir" "$data_zip_archive"
 
+echo 'Preprocessing files...' >&2
+
+printf '%s\0' "$tmpdir"/*.tab |
+xargs -0 -P "$(nproc)" -n 50 sh -c '
+	mlr -I --t2c clean-whitespace "$@"
+	for name do
+		mv -- "$name" "${name%.tab}.csv"
+	done' sh
+
 echo 'Loading files into database...' >&2
 
 cat <<-'SQL' >"$tmpdir/import.sql"
-	.mode tabs
+	.mode csv
 	PRAGMA temp_store = MEMORY;
 	CREATE TEMPORARY TABLE import_tmp (
 		query TEXT NOT NULL,
@@ -61,7 +70,7 @@ cat <<-'SQL' >"$tmpdir/import.sql"
 	);
 SQL
 
-printf '.import --skip 1 %s import_tmp\n' "$tmpdir"/*.tab >>"$tmpdir/import.sql"
+printf '.import --skip 1 %s import_tmp\n' "$tmpdir"/*.csv >>"$tmpdir/import.sql"
 
 cat <<-'SQL' >>"$tmpdir/import.sql"
 	INSERT INTO predicted_unique_homologues (

--- a/database/scripts/import-sensitivity-distributions.sh
+++ b/database/scripts/import-sensitivity-distributions.sh
@@ -39,6 +39,7 @@ done
 mlr --csv \
 	rename 'strain,Strain,Incubation time (),Incubation time (h)' then \
 	put 'is_empty($Comment) { $["Unnamed: 13"] = $Comment; $["Unnamed: 13"] = ""; }' then \
+	clean-whitespace then \
 	remove-empty-columns \
 	"$tmpdir"/*.csv >"$tmpdir/data.csv"
 

--- a/database/scripts/import-validated-compounds.sh
+++ b/database/scripts/import-validated-compounds.sh
@@ -25,11 +25,15 @@ fi
 
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
 # This data needs to be preprocessed to remove empty records and
 # internal headers.  There are characters that are not UTF-8 (these are
 # dropped).
+
+echo 'Preprocessing data...' >&2
 iconv -c -t UTF-8 "$1" |
-awk 'NR == 1 || !(/,,,/ || /CAS Number,Chemical Class/)' >"$tmpdir/data.csv"
+awk 'NR == 1 || !(/,,,/ || /CAS Number,Chemical Class/)' |
+mlr --csv clean-whitespace >"$tmpdir/data.csv"
 
 echo 'Loading data into database...' >&2
 

--- a/database/scripts/import-validated.sh
+++ b/database/scripts/import-validated.sh
@@ -25,11 +25,15 @@ fi
 
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
 # This data needs to be preprocessed to remove characters that are not
 # UTF-8 and to correct some misspelled terms.
 # shellcheck disable=SC2016
+
+echo 'Preprocessing data...' >&2
+
 iconv -c -t UTF-8 "$1" |
-mlr --csv put '
+mlr --csv clean-whitespace then put '
 	$Compound = gssub($Compound,
 		"Benzylkonium Chloride (BAC)", 
 		"Benzalkonium Chloride (BAC)");


### PR DESCRIPTION
Flanking whitespace is removed from each field, and multiple consecutive whitespaces are collapsed into a single space.

This is done for all data except for the PDB files (these are read as-is).

The fix is implemented using the `clean-whitespace` operation of Miller (`mlr`).  For some of the data, which was previously imported without modification, this means an additional processing step and, consequently, a slightly longer data import run.

## Testing

* First notice that there is data with problematic whitespace in the database:
`docker compose run --rm database sqlite3 data/database.db '.mode csv' 'select distinct biocide from sensitivity_distributions where biocide like "Alkyldiaminoethylglycine hydrochloride%"'` (output: `"Alkyldiaminoethylglycine hydrochloride "`, note the space at the end).
* Load the data anew: `DATABASE_REINIT=1 docker compose --profile=load-data up --build database`
* Run the first command again to see the space removed.
