### PR TITLE
Add sensitivity distributions links in the navigation

### DIFF
--- a/frontend/bacmet/app/components/nav-bar-core.tsx
+++ b/frontend/bacmet/app/components/nav-bar-core.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+
+export interface NavBarProps {
+  navigation: { label: string, href?: string, dropdown?: { label: string, href: string }[] }[];
+  brandName: string;
+  pathname?: string;
+}
+
+export default function NavBarCore({ navigation, brandName, pathname }: NavBarProps) {
+  return (
+    <nav className="navbar navbar-expand-lg navbar-light bg-primary">
+      <div className="container-fluid justify-content-between">
+        <div>
+          <Link className="navbar-brand text-white me-1" href="/">{brandName}</Link> <i className="bi bi-virus text-white"></i>
+        </div>
+        <button className="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
+          aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+          <span className="navbar-toggler-icon"></span>
+        </button>
+        <div className="collapse navbar-collapse" id="navbarSupportedContent">
+          <ul className="navbar-nav ms-auto">
+            {navigation.map((item, index) =>
+              item.dropdown ? (
+                <li key={index} className="nav-item dropdown me-2">
+                  <a
+                    className={`nav-link dropdown-toggle text-white${pathname && pathname.startsWith("/sensitivity-distributions/") ? " active" : ""}`}
+                    href="#"
+                    id={`navbarDropdown-${index}`}
+                    role="button"
+                    data-bs-toggle="dropdown"
+                    aria-expanded="false"
+                  >
+                    {item.label}
+                  </a>
+                  <ul className="dropdown-menu bg-primary" aria-labelledby={`navbarDropdown-${index}`}>
+                    {item.dropdown.map((dropItem, dropIndex) => (
+                      <li key={dropIndex}>
+                        <Link className={`dropdown-item text-white${pathname === dropItem.href ? " active" : ""}`} href={dropItem.href}>
+                          {dropItem.label}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              ) : item.href ? (
+                <li key={index} className="nav-item me-2">
+                  <Link className={`nav-link text-white${pathname === item.href ? " active" : ""}`} href={item.href}>
+                    {item.label}
+                  </Link>
+                </li>
+              ) : null
+            )}
+          </ul>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/frontend/bacmet/app/components/nav-bar-core.tsx
+++ b/frontend/bacmet/app/components/nav-bar-core.tsx
@@ -22,16 +22,15 @@ export default function NavBarCore({ navigation, brandName, pathname }: NavBarPr
             {navigation.map((item, index) =>
               item.dropdown ? (
                 <li key={index} className="nav-item dropdown me-2">
-                  <a
+                  <button
                     className={`nav-link dropdown-toggle text-white${pathname && pathname.startsWith("/sensitivity-distributions/") ? " active" : ""}`}
-                    href="#"
                     id={`navbarDropdown-${index}`}
-                    role="button"
+                    type="button"
                     data-bs-toggle="dropdown"
                     aria-expanded="false"
                   >
                     {item.label}
-                  </a>
+                  </button>
                   <ul className="dropdown-menu bg-primary" aria-labelledby={`navbarDropdown-${index}`}>
                     {item.dropdown.map((dropItem, dropIndex) => (
                       <li key={dropIndex}>

--- a/frontend/bacmet/app/components/navbar.tsx
+++ b/frontend/bacmet/app/components/navbar.tsx
@@ -1,0 +1,11 @@
+"use client"
+import { usePathname } from "next/navigation";
+
+import NavBarCore, { NavBarProps } from "./nav-bar-core"
+
+export default function NavBar(props: NavBarProps) {
+  const pathname = usePathname();
+
+  return <NavBarCore {...props} pathname={pathname} />;
+
+}

--- a/frontend/bacmet/app/layout.tsx
+++ b/frontend/bacmet/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Image from "next/image";
-import Link from "next/link";
+import NavBarCore from "./components/nav-bar-core";
+import NavBar from "./components/navbar";
+import { Suspense } from "react";
 
 export const metadata: Metadata = {
   description: "BacMet is an easy-to-use bioinformatics resource of antibacterial biocide- and metal-resistance genes.",
@@ -17,18 +19,18 @@ export default function RootLayout({
   const contact = "info@example.com";
   const attribution = "BacMet database/website was developed and designed by Chandan Pal and currently maintained by Joakim Larsson's team";
   const navigation: ({ label: string, href?: string, dropdown?: { label: string, href: string }[] })[] = [
-    { label: "Search", href: "/search" },
-    { label: "Sensitivity Distributions", // This remains as a dropdown
+    { label: "Search", href: "/search/" },
+    { label: "Sensitivity Distributions",
       dropdown: [
-        { label: "For species", href: "/sensitivity-distributions/species" },
-        { label: "For biocides", href: "/sensitivity-distributions/biocide" },
+        { label: "For species", href: "/sensitivity-distributions/species/" },
+        { label: "For biocides", href: "/sensitivity-distributions/biocide/" },
       ]
     },
     { label: "BLAST", href: "#" },
     { label: "Download", href: "#" },
-    { label: "FAQ", href: "/faq" },
-    { label: "About", href: "/about" },
-    { label: "Contact", href: "/contact" },
+    { label: "FAQ", href: "/faq/" },
+    { label: "About", href: "/about/" },
+    { label: "Contact", href: "/contact/" },
   ];
 
   return (
@@ -45,44 +47,9 @@ export default function RootLayout({
       <body>
         <header>
           {navigation.length > 0 ? (
-            <nav className="navbar navbar-expand-lg navbar-light bg-primary">
-              <div className="container-fluid justify-content-between">
-                <div>
-                  <Link className="navbar-brand text-white me-1" href="/">{brandName}</Link> <i className="bi bi-virus text-white"></i>
-                </div>
-                <button className="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
-                  aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                  <span className="navbar-toggler-icon"></span>
-                </button>
-                <div className="collapse navbar-collapse" id="navbarSupportedContent">
-                  <ul className="navbar-nav ms-auto">
-                    {navigation.map((item, index) => {
-                      if (item.dropdown) {
-                        return (
-                          <li key={index} className="nav-item dropdown me-2">
-                            <a className="nav-link dropdown-toggle text-white" href="#" id={`navbarDropdown-${index}`} role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                              {item.label}
-                            </a>
-                            <ul className="dropdown-menu bg-primary" aria-labelledby={`navbarDropdown-${index}`}>
-                              {item.dropdown.map((dropItem, dropIndex) => (
-                                <li key={dropIndex}><Link className="dropdown-item text-white" href={dropItem.href}>{dropItem.label}</Link></li>
-                              ))}
-                            </ul>
-                          </li>
-                        );
-                      }
-                      else if (item.href) {
-                        return (
-                          <li key={index} className="nav-item me-2"><Link className="nav-link text-white" href={item.href} >{item.label}</Link></li>
-                        );
-                      } else {
-                        return null;
-                      }
-                    })}
-                  </ul>
-                </div>
-              </div>
-            </nav>
+            <Suspense fallback={<NavBarCore navigation={navigation} brandName={brandName} /> }>
+              <NavBar navigation={navigation} brandName={brandName} />
+            </Suspense>
           ) : <></>}
         </header>
         <main className="container">

--- a/frontend/bacmet/app/layout.tsx
+++ b/frontend/bacmet/app/layout.tsx
@@ -16,14 +16,21 @@ export default function RootLayout({
   const copyright = "Copyright © 2013-2018 All rights reserved";
   const contact = "info@example.com";
   const attribution = "BacMet database/website was developed and designed by Chandan Pal and currently maintained by Joakim Larsson's team";
-  const navigation: { label: string, href: string }[] = [
-    ["Search", "/search"],
-    ["BLAST", "#"],
-    ["Download", "#"],
-    ["FAQ", "/faq"],
-    ["About", "/about"],
-    ["Contact", "/contact"],
-  ].map(([label, href]) => ({ label, href }));
+  const navigation: ({ label: string, href?: string, dropdown?: { label: string, href: string }[] })[] = [
+    { label: "Search", href: "/search" },
+    { label: "Sensitivity Distributions", // This remains as a dropdown
+      dropdown: [
+        { label: "For species", href: "/sensitivity-distributions/species" },
+        { label: "For biocides", href: "/sensitivity-distributions/biocide" },
+      ]
+    },
+    { label: "BLAST", href: "#" },
+    { label: "Download", href: "#" },
+    { label: "FAQ", href: "/faq" },
+    { label: "About", href: "/about" },
+    { label: "Contact", href: "/contact" },
+  ];
+
   return (
     <html lang="en">
       <head>
@@ -49,9 +56,29 @@ export default function RootLayout({
                 </button>
                 <div className="collapse navbar-collapse" id="navbarSupportedContent">
                   <ul className="navbar-nav ms-auto">
-                    {navigation.map((item, index) => (
-                      <li key={index} className="nav-item me-2"><Link className="nav-link text-white" href={item.href}>{item.label}</Link></li>
-                    ))}
+                    {navigation.map((item, index) => {
+                      if (item.dropdown) {
+                        return (
+                          <li key={index} className="nav-item dropdown me-2">
+                            <a className="nav-link dropdown-toggle text-white" href="#" id={`navbarDropdown-${index}`} role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                              {item.label}
+                            </a>
+                            <ul className="dropdown-menu bg-primary" aria-labelledby={`navbarDropdown-${index}`}>
+                              {item.dropdown.map((dropItem, dropIndex) => (
+                                <li key={dropIndex}><Link className="dropdown-item text-white" href={dropItem.href}>{dropItem.label}</Link></li>
+                              ))}
+                            </ul>
+                          </li>
+                        );
+                      }
+                      else if (item.href) {
+                        return (
+                          <li key={index} className="nav-item me-2"><Link className="nav-link text-white" href={item.href} >{item.label}</Link></li>
+                        );
+                      } else {
+                        return null;
+                      }
+                    })}
                   </ul>
                 </div>
               </div>

--- a/frontend/bacmet/public/main.css
+++ b/frontend/bacmet/public/main.css
@@ -105,6 +105,13 @@ legend {
   margin: 0;
 }
 
+ul.dropdown-menu > .dropdown-item.text-white:hover,
+ul.dropdown-menu > .dropdown-item.text-white:focus,
+ul.dropdown-menu > li > .dropdown-item.text-white:hover,
+ul.dropdown-menu > li > .dropdown-item.text-white:focus {
+  background-color: var(--bs-primary-hover);
+}
+
 @media (max-width: 768px) {
   .bg-image {
     height: 250px;

--- a/frontend/bacmet/public/main.css
+++ b/frontend/bacmet/public/main.css
@@ -9,7 +9,7 @@
   --bs-gray-100: #fbfbfb;
   --bs-gray-100-rgb: 251, 251, 251;
   --bs-primary-hover: #394A62;
-  --bs-primary-hover-rgb: 57, 74, 98; 
+  --bs-primary-hover-rgb: 57, 74, 98;
 }
 
 body {

--- a/frontend/bacmet/public/main.css
+++ b/frontend/bacmet/public/main.css
@@ -109,10 +109,8 @@ legend {
   margin: 0;
 }
 
-ul.dropdown-menu > .dropdown-item.text-white:hover,
-ul.dropdown-menu > .dropdown-item.text-white:focus,
-ul.dropdown-menu > li > .dropdown-item.text-white:hover,
-ul.dropdown-menu > li > .dropdown-item.text-white:focus {
+.dropdown-item.text-white:hover,
+.dropdown-item.text-white:focus {
   background-color: var(--bs-primary-hover);
 }
 

--- a/frontend/bacmet/public/main.css
+++ b/frontend/bacmet/public/main.css
@@ -8,6 +8,8 @@
   --bs-footer-rgb: 226, 218, 214;
   --bs-gray-100: #fbfbfb;
   --bs-gray-100-rgb: 251, 251, 251;
+  --bs-primary-hover: #394A62;
+  --bs-primary-hover-rgb: 57, 74, 98; 
 }
 
 body {
@@ -43,8 +45,14 @@ header > .navbar .nav-item {
   background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='rgba(255,255,255,1)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3E%3C/svg%3E");
 }
 
-.nav-link.active {
+.nav-link.active,
+.dropdown-item.active {
   text-decoration: underline;
+  text-underline-offset: 0.3em;
+}
+
+.dropdown-item.active {
+  background-color: var(--bs-primary);
 }
 
 .btn-primary {
@@ -77,10 +85,6 @@ legend {
   font-size: 1rem;
   font-weight: normal;
   margin-bottom: 0.5em;
-}
-
-.nav-link.active {
-  text-decoration: underline;
 }
 
 .bg-image {


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes https://github.com/NBISweden/bacmet/issues/100 :tada: 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## List of changes made
- Add links for sensitivity distributions-pages in the navbar
- Refactor `navbar` in order to be able to use `pathname` and the `.active` CSS-class in order to underline the current page in the `navbar`. 
   - This included creating additional components due to the server-side rendering. 
 - Add necessary CSS-styles. 

## Screenshot of the fix
<img width="1264" height="351" alt="image" src="https://github.com/user-attachments/assets/9fa39ae2-b893-4a4b-aefc-9da5f0e38480" />

<img width="1264" height="351" alt="image" src="https://github.com/user-attachments/assets/d4c2753d-5bd0-432a-ab81-6add3a6eafd2" />


## Testing
- Check out this branch and navigate in the navbar and see the expected behaviour. The links that are not currently working are: `Download` and `BLAST`. 

## Further comments
Mattias helped a lot with this! :pray: 

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any