### PR TITLE
feat: add possibility to use wildcard for free text search

### DIFF
--- a/app/app/search.py
+++ b/app/app/search.py
@@ -1,6 +1,7 @@
 from sqlalchemy import select
 from sqlalchemy.sql import func, collate
 from sqlalchemy.orm import joinedload
+import re
 from typing import Optional, Tuple
 from .database import (
     db_session,
@@ -64,9 +65,9 @@ def apply_search_filters(
     if free_text:
         search_pattern = build_wildcard_pattern(free_text)
         stmt = stmt.filter(
-            (Validated.gene_name.ilike(search_pattern)) |
-            (Validated.compounds.any(Compounds.compound_name.ilike(search_pattern))) |
-            (Validated.compounds.any(Compounds.chemical_class.ilike(search_pattern)))
+            (func.trim(Validated.gene_name).ilike(search_pattern, escape='\\')) |
+            (Validated.compounds.any(func.trim(Compounds.compound_name).ilike(search_pattern, escape='\\'))) |
+            (Validated.compounds.any(func.trim(Compounds.chemical_class).ilike(search_pattern, escape='\\')))
         )
     return stmt
 
@@ -230,14 +231,8 @@ def get_gene_names(
         ]
 
 def build_wildcard_pattern(free_text: str) -> str:
-    pattern = free_text.replace('*', '%')
-    while '%%' in pattern:
-        pattern = pattern.replace('%%', '%')
+    pattern = re.sub(r"([%_])", r"\\\1", free_text)
     if '*' not in free_text:
-        pattern = f"%{pattern}%"
-    else:
-        if free_text.startswith('*') and not pattern.startswith('%'):
-            pattern = '%' + pattern
-        if free_text.endswith('*') and not pattern.endswith('%'):
-            pattern = pattern + '%'
+        return f"%{pattern}%"
+    pattern = re.sub(r"\*+", "%", pattern)
     return pattern

--- a/app/app/search.py
+++ b/app/app/search.py
@@ -62,7 +62,7 @@ def apply_search_filters(
             Validated.gene_name.in_(gene_name)
         )
     if free_text:
-        search_pattern = f"%{free_text}%"
+        search_pattern = f"%{free_text.replace('*', '%')}%"
         stmt = stmt.filter(
             (Validated.gene_name.ilike(search_pattern)) |
             (Validated.compounds.any(Compounds.compound_name.ilike(search_pattern))) |

--- a/app/app/search.py
+++ b/app/app/search.py
@@ -62,7 +62,7 @@ def apply_search_filters(
             Validated.gene_name.in_(gene_name)
         )
     if free_text:
-        search_pattern = f"%{free_text.replace('*', '%')}%"
+        search_pattern = build_wildcard_pattern(free_text)
         stmt = stmt.filter(
             (Validated.gene_name.ilike(search_pattern)) |
             (Validated.compounds.any(Compounds.compound_name.ilike(search_pattern))) |
@@ -228,3 +228,16 @@ def get_gene_names(
             item[0]
             for item in list(session.execute(summary_stmt))
         ]
+
+def build_wildcard_pattern(free_text: str) -> str:
+    pattern = free_text.replace('*', '%')
+    while '%%' in pattern:
+        pattern = pattern.replace('%%', '%')
+    if '*' not in free_text:
+        pattern = f"%{pattern}%"
+    else:
+        if free_text.startswith('*') and not pattern.startswith('%'):
+            pattern = '%' + pattern
+        if free_text.endswith('*') and not pattern.endswith('%'):
+            pattern = pattern + '%'
+    return pattern

--- a/frontend/bacmet/public/markdown-content/index.md
+++ b/frontend/bacmet/public/markdown-content/index.md
@@ -3,7 +3,7 @@ heroText: BacMet is an easy-to-use bioinformatics resource of antibacterial bioc
 heroImage: /img/hero-image.jpg
 quickSearchDescription: |
   ## Quick search
-  You can search the BacMet database using any full term, including for example gene names (e.g. copA), name of biocides (e.g. Triclosan), metals (e.g. Arsenic) or chemical classes (ex. Acridine). You will be redirected to the search page.
+  You can search the BacMet database using any full term, including for example gene names (e.g. copA), name of biocides (e.g. Triclosan), metals (e.g. Arsenic) or chemical classes (e.g. Acridine). You will be redirected to the search page. The search also supports wildcard like this (e.g. Ar*nic for Arsenic or *ine for Diamidine)
 ---
 
 # Bacmet Database


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes https://github.com/NBISweden/bacmet/issues/93

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## List of changes made
- Added possibility to use `*` as a wildcard in the free text search. 
- Escape characters like `%` and `_` so that they interpreted as literal characters.

## Testing
Check out this branch and try searching with and without the wildcard (`triclosan` is the example below):
- `triclosan`
- `triclo`
- `tr*an`
- `*san`
- `tri*`

Make sure you get the expected result.

Note that the free text search searches among gene names, compound names and chemical classes. 

## Further comments
This PR does not include any ranking of the results. This is handled in a separate issue. 

Also, note that this functionality also searches in the `chemical class` field. This leads to that it's not super obvious why some hits appear in the search result list, as the chemical class field is not present among the other fields of a search hit. If that happens you can tick off one or more chemical classes in the options menu (that matches your search term) and see if the specific search hit is still there. 

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any