### PR TITLE
Create static download-page with links

### DIFF
--- a/frontend/bacmet/app/about/page.tsx
+++ b/frontend/bacmet/app/about/page.tsx
@@ -10,7 +10,7 @@ export default function About() {
   const { content } = matter(fileContent);
 
   return (
-    <div className="text-center pt-3">
+    <div className="pt-3">
       <Markdown>{content}</Markdown>
     </div>
   );

--- a/frontend/bacmet/app/components/markdown-util.tsx
+++ b/frontend/bacmet/app/components/markdown-util.tsx
@@ -5,7 +5,7 @@ export default function Markdown({ children }: { children: string }) {
     <ReactMarkdown
       components={{
         img: ({ node, ...props }) => (
-          <img {...props} className="img-fluid" />
+          <img {...props} className="img-fluid" style={{ display: "block", marginLeft: "auto", marginRight: "auto" }} />
         ),
       }}
     >

--- a/frontend/bacmet/app/contact/page.tsx
+++ b/frontend/bacmet/app/contact/page.tsx
@@ -28,7 +28,7 @@ export default function Contact() {
 
   return (
     <>
-      <div className="text-center pt-3">
+      <div className="pt-3">
         <Markdown>{content}</Markdown>
       </div>
       <div className="row justify-content-center">

--- a/frontend/bacmet/app/download/page.tsx
+++ b/frontend/bacmet/app/download/page.tsx
@@ -1,0 +1,17 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+import React from "react";
+import Markdown from "../components/markdown-util";
+
+export default function Download() {
+  const filePath = path.join(process.cwd(), "public/markdown-content/download.md");
+  const fileContent = fs.readFileSync(filePath, "utf8");
+  const { content } = matter(fileContent);
+
+  return (
+    <div className="pt-3">
+      <Markdown>{content}</Markdown>
+    </div>
+  );
+}

--- a/frontend/bacmet/app/faq/page.tsx
+++ b/frontend/bacmet/app/faq/page.tsx
@@ -25,7 +25,7 @@ export default function FAQPage() {
 
   return (
     <>
-      <div className="text-center py-3">
+      <div className="py-3">
         <Markdown>{content}</Markdown>
       </div>
       <div className="row row-gap-3">

--- a/frontend/bacmet/app/layout.tsx
+++ b/frontend/bacmet/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
       ]
     },
     { label: "BLAST", href: "#" },
-    { label: "Download", href: "#" },
+    { label: "Download", href: "/download/" },
     { label: "FAQ", href: "/faq/" },
     { label: "About", href: "/about/" },
     { label: "Contact", href: "/contact/" },

--- a/frontend/bacmet/app/page.tsx
+++ b/frontend/bacmet/app/page.tsx
@@ -39,7 +39,7 @@ export default function Home() {
 
   return (
     <>
-      <div className="text-center bg-image position-relative" style={{ backgroundImage: `url('${indexProps.heroImage}')` }}>
+      <div className="bg-image position-relative" style={{ backgroundImage: `url('${indexProps.heroImage}')` }}>
         <div className="d-flex justify-content-center align-items-center h-100">
           <div className="bg-dark bg-opacity-75 px-4 py-3">
             <p className="hero-image-text">{indexProps.heroText}</p>

--- a/frontend/bacmet/app/search/entry/page.tsx
+++ b/frontend/bacmet/app/search/entry/page.tsx
@@ -125,7 +125,7 @@ function EntryViewWithParams() {
   return (
     <>
       <div className="col-sm-12 col-md-9 col-lg-7">
-        <h1 className="text-center">{validatedEntry.gene_name}: {validatedEntry.organism} ({validatedEntry.bacmet_id})</h1>
+        <h1>{validatedEntry.gene_name}: {validatedEntry.organism} ({validatedEntry.bacmet_id})</h1>
         <ValidatedEntry entry={validatedEntry} />
       </div>
       {predictedResult ? (

--- a/frontend/bacmet/app/search/page.tsx
+++ b/frontend/bacmet/app/search/page.tsx
@@ -240,7 +240,7 @@ const SearchBase = (
   return (
     <div className="row justify-content-center pt-3 pb-3">
       <div className="col-sm-12 col-md-9 col-lg-7">
-        <h1 className="text-center">Search</h1>
+        <h1>Search</h1>
         <p>Lorem ipsum dolor sit amet, vince adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
           aliqua. Utenim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute
           irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>

--- a/frontend/bacmet/public/main.css
+++ b/frontend/bacmet/public/main.css
@@ -21,6 +21,10 @@ body {
     padding: 0;
 }
 
+h1 {
+  text-align: center;
+}
+
 body > main {
     flex-grow: 1;
     flex-shrink: 0;
@@ -107,6 +111,7 @@ legend {
   font-weight: 500;
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
   margin: 0;
+  text-align: center;
 }
 
 .dropdown-item.text-white:hover,

--- a/frontend/bacmet/public/markdown-content/download.md
+++ b/frontend/bacmet/public/markdown-content/download.md
@@ -1,0 +1,25 @@
+# Download
+Below you can find links of datasets from the Bacmet database. 
+
+## BacMet (version 2.0) (11 March 2018)
+- [BacMet2 Experimentally confirmed resistance genes](http://bacmet.biomedicine.gu.se/download/BacMet2_EXP_database.fasta) (753 resistance genes, FASTA format)
+- [BacMet2 Predicted resistance genes](http://bacmet.biomedicine.gu.se/download/BacMet2_predicted_database.fasta.gz) (155,512 resistance genes, FASTA format)
+- [Gene annotation mapping file for BacMet2 Experimentally Confirmed Resistance Genes Database](http://bacmet.biomedicine.gu.se/download/BacMet2_EXP.753.mapping.txt)
+- [Gene annotation mapping file for BacMet2 Predicted Resistance Genes Database](http://bacmet.biomedicine.gu.se/download/BacMet2_PRE.155512.mapping.txt)
+
+## BacMet (version 1.1) (16 January 2014)
+- [BacMet Experimentally Confirmed Resistance Genes](http://bacmet.biomedicine.gu.se//BacMet_EXP.704.fasta) (704 resistance genes, FASTA format)
+- [BacMet Experimentally Confirmed Biocide Resistance Genes](http://bacmet.biomedicine.gu.se/download/BacMet_EXP.BAC0000.BIOCIDES.325.fasta) (325 resistance genes, FASTA format)
+- [BacMet Experimentally Confirmed Metal Resistance Genes](http://bacmet.biomedicine.gu.se/download/BacMet_EXP.BAC0000.METALS.444.fasta) (444 resistance genes, FASTA format)
+- [BacMet Predicted Resistance Genes](http://bacmet.biomedicine.gu.se/download/BacMet_PRE.40556.fasta) (40,556 resistance genes, FASTA format)
+- [BacMet Experimentally Confirmed database mapping file](http://bacmet.biomedicine.gu.se/download/BacMet_EXP.704.mapping.txt)
+- [BacMet Predicted Resistance Genes Database mapping file](http://bacmet.biomedicine.gu.se/download/BacMet_PRE.40556.mapping.txt)
+- [The BacMet-Scan script file.pl](http://bacmet.biomedicine.gu.se/download/BacMet-Scan)
+
+## BacMet (version 1.0) (5 November 2013)
+- [All files.zip](http://bacmet.biomedicine.gu.se/download/BacMet1.0.zip) (.zip format)
+- [The BacMet-Scan script file.pl](http://bacmet.biomedicine.gu.se/download/BacMet-Scan)
+- [BacMet Experimentally Confirmed Dataset.fasta](http://bacmet.biomedicine.gu.se/download/BacMet_EXP.470.fasta) (470 resistance genes)
+- [BacMet Predicted Resistance Genes Dataset.fasta](http://bacmet.biomedicine.gu.se/download/BacMet_ALL.25477.fasta) (25477 resistance genes)
+- [BacMet Experimentally Confirmed dataset mapping file.txt](http://bacmet.biomedicine.gu.se/download/BacMet_EXP.mapping.470.txt)
+- [BacMet Predicted Resistance Genes Dataset mapping file.txt](http://bacmet.biomedicine.gu.se/download/BacMet_ALL_25477.mapping.txt)


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes https://github.com/NBISweden/bacmet/issues/110

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## List of changes made
- Add static Download-page and possibility to update it with markdown
- Added current download links for the Bacmet database
- Removed `text-center` class from divs in pages and added `text-align: center` to `h1`-element instead.
- Centered images added via markdown.

## Screenshot of the fix
<img width="2486" height="1916" alt="image" src="https://github.com/user-attachments/assets/2c54fdda-0c99-48d7-b646-d69598715b6a" />

## Testing
View the page  :sparkles: 

## Further comments
The links are now simply taken from the old website.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any