### PR TITLE
Add page to list compounds

### DIFF
--- a/frontend/bacmet/app/compounds/page.tsx
+++ b/frontend/bacmet/app/compounds/page.tsx
@@ -31,7 +31,9 @@ function CompoundListWithData() {
 function CompoundList({entries}: {entries: Compound[]}) {
   const [usedChemcialClasses, setUsedChemicalClasses] = useState<Set<unknown>>(new Set());
   const chemicalClasses = useMemo(() => (
-    Array.from(new Set<string>(entries.map(c => c.chemical_class))).map<FieldValue>(cc => ({value: cc, label: cc}))
+    Array.from(new Set<string>(entries.map(c => c.chemical_class)))
+    .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+    .map<FieldValue>(cc => ({value: cc, label: cc}))
   ), [entries]);
   const chemicalClassField: MultiValueField = useMemo(() => ({
     label: "Filter by chemical classes",

--- a/frontend/bacmet/app/compounds/page.tsx
+++ b/frontend/bacmet/app/compounds/page.tsx
@@ -1,0 +1,90 @@
+"use client"
+import { useConfig } from "../../contexts/config";
+import { Suspense, useCallback, useState, useMemo } from "react";
+import { Compound, Result, MultiValueField, FieldValue } from "../search/types";
+import { usePromiseData, fetchData } from "../utils";
+import { MultiSelectField } from "../search/components/multi-select-field/multi-select-field";
+import Link from 'next/link'
+
+const DefaultCompounds: Result<Compound> = {
+  items: [],
+  _meta: {
+    totalRecords: 0,
+    totalPages: 0,
+    page: 0,
+    count: 0,
+  },
+  _links: [],
+}
+
+function CompoundListWithData() {
+  const {apiRoot} = useConfig();
+
+  const compoundsFetcher = useCallback(() => fetchData<Result<Compound>>(`${apiRoot}/aggregated/compound`), [apiRoot]);
+  const compounds = usePromiseData(compoundsFetcher, DefaultCompounds).items;
+
+  return (
+    <CompoundList entries={compounds} />
+  )
+}
+
+function CompoundList({entries}: {entries: Compound[]}) {
+  const [usedChemcialClasses, setUsedChemicalClasses] = useState<Set<unknown>>(new Set());
+  const chemicalClasses = useMemo(() => (
+    Array.from(new Set<string>(entries.map(c => c.chemical_class))).map<FieldValue>(cc => ({value: cc, label: cc}))
+  ), [entries]);
+  const chemicalClassField: MultiValueField = useMemo(() => ({
+    label: "Filter by chemical classes",
+    name: "chemical_class",
+    value: Array.from(usedChemcialClasses || []),
+    values: chemicalClasses,
+  }), [usedChemcialClasses, chemicalClasses]);
+  const handleSelectedChemicalClass = useCallback((value: unknown[]) => setUsedChemicalClasses(new Set(value)), [setUsedChemicalClasses])
+  const filteredEntries = entries.filter(c => usedChemcialClasses.size > 0 ? usedChemcialClasses.has(c.chemical_class) : true );
+  return (
+    <div className="col-sm-12 col-md-9 col-lg-7">
+      <h1 className="text-center">Compounds</h1>
+      <MultiSelectField field={chemicalClassField} onChange={handleSelectedChemicalClass}/>
+      <hr />
+      <table className="table">
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Chemical Class</th>
+            <th scope="col">CAS Number</th>
+            <th scope="col">Search</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filteredEntries.map(entry => {
+            const searchByChemicalClassUrl = `/search/?${new URLSearchParams({chemical_class: entry.chemical_class})}`;
+            const searchByCompoundUrl = `/search/?${new URLSearchParams({compound: entry.compound_name})}`;
+            return (
+              <tr key={entry.compound_name}>
+                <td scope="col">{entry.compound_name}</td>
+                <td scope="col">{entry.chemical_class}</td>
+                <td scope="col">{entry.cas_number}</td>
+                <td scope="col">
+                  <ul>
+                    <li className="text-nowrap"><Link href={searchByChemicalClassUrl}>By Chemical Class</Link></li>
+                    <li className="text-nowrap"><Link href={searchByCompoundUrl}>By Compound</Link></li>
+                  </ul>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default function CompoundsPage() {
+  return (
+    <div className="row justify-content-center pt-3 pb-3">
+      <Suspense fallback={<CompoundList entries={[]}/>}>
+        <CompoundListWithData />
+      </Suspense>
+    </div>
+  );
+}

--- a/frontend/bacmet/app/layout.tsx
+++ b/frontend/bacmet/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
         { label: "For biocides", href: "/sensitivity-distributions/biocide/" },
       ]
     },
-    { label: "BLAST", href: "#" },
+    { label: "Compounds", href: "/compounds/" },
     { label: "Download", href: "/download/" },
     { label: "FAQ", href: "/faq/" },
     { label: "About", href: "/about/" },


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->
## Related issue(s) and PR(s)

This PR closes #108 

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## List of changes made

- Add page to list compounds
- Add link to page in navbar

## Screenshot of the fix

<img width="2208" height="2468" alt="Screen Shot 2025-09-17 at 16 00 53" src="https://github.com/user-attachments/assets/01649f0e-2b19-4205-87b2-216dce5dc9f9" />

## Testing

- Go to: http://localhost:5000/compounds/
- Filter the compounds using the multiselect
- Use the links and verify that you are taken to a relevant search

## Further comments

Depending on when this is merged I will leave the link to the details view of compounds to be implemented in #109 

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any