### PR TITLE
Create compound view page

### DIFF
--- a/app/app/main.py
+++ b/app/app/main.py
@@ -16,6 +16,7 @@ from .search import (
     get_compounds,
     get_gene_names,
     get_from_validated,
+    get_from_compounds
 )
 from .sensitivity_distributions import (
     get_sensitivity_histogram,
@@ -392,6 +393,21 @@ def sensitivity_distributions_aggregated(param: str):
     )
     return jsonify(dataclasses.asdict(result))
 
+
+@app.route('/api/compound/<compound_name>')
+@cross_origin()
+def compound_entry(compound_name: str):
+    compound = get_from_compounds(compound_name)
+    if compound is None:
+        return make_error(f"No entry found for: {compound_name}")
+    from .types import Compound 
+    compound_data = Compound(
+        compound_name=compound.compound_name,
+        chemical_class=compound.chemical_class,
+        cas_number=compound.cas_number,
+        description=compound.description
+    )
+    return jsonify(dataclasses.asdict(compound_data))
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8000)

--- a/app/app/main.py
+++ b/app/app/main.py
@@ -400,7 +400,7 @@ def compound_entry(compound_name: str):
     compound = get_from_compounds(compound_name)
     if compound is None:
         return make_error(f"No entry found for: {compound_name}")
-    from .types import Compound 
+    
     compound_data = Compound(
         compound_name=compound.compound_name,
         chemical_class=compound.chemical_class,

--- a/app/app/main.py
+++ b/app/app/main.py
@@ -394,7 +394,7 @@ def sensitivity_distributions_aggregated(param: str):
     return jsonify(dataclasses.asdict(result))
 
 
-@app.route('/api/compound/<compound_name>')
+@app.route('/api/compound/<path:compound_name>')
 @cross_origin()
 def compound_entry(compound_name: str):
     compound = get_from_compounds(compound_name)

--- a/app/app/search.py
+++ b/app/app/search.py
@@ -93,6 +93,16 @@ def get_from_validated(
         (value,) = session.execute(stmt).first()
         return value
 
+def get_from_compounds(
+    compound_name
+) -> Compounds:
+    stmt = select(Compounds).where(Compounds.compound_name == compound_name)
+    with db_session() as session:
+        result = session.execute(stmt).first()
+        if result:
+            (compound,) = result
+            return compound
+        return None
 
 def find_in_validated(
     chemical_class: Optional[list[str]],

--- a/app/app/types.py
+++ b/app/app/types.py
@@ -44,6 +44,7 @@ class Compound:
     compound_name: str
     chemical_class: str
     cas_number: str
+    description: Optional[str] = None
 
 
 @dataclasses.dataclass

--- a/frontend/bacmet/app/compounds/entry/page.tsx
+++ b/frontend/bacmet/app/compounds/entry/page.tsx
@@ -1,29 +1,10 @@
 "use client";
 import { useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useState, Suspense } from "react";
 import { useConfig } from "../../../contexts/config";
 import { Compound } from "../../search/types";
 
-export default function CompoundEntryPage() {
-  const { apiRoot } = useConfig();
-  const searchParams = useSearchParams();
-  const compoundName = searchParams.get("compound_name");
-  const [compound, setCompound] = useState<Compound | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!compoundName) return;
-    setError(null);
-
-    fetch(`${apiRoot}/compound/${encodeURIComponent(compoundName)}`)
-      .then((res) => {
-        if (!res.ok) throw new Error("not found");
-        return res.json();
-      })
-      .then((data) => setCompound(data))
-      .catch((e) => setError(e.message))
-  }, [apiRoot, compoundName]);
-
+function CompoundEntry({ compound, error, compoundName }: { compound: Compound | null, error: string | null, compoundName?: string | null }) {
   return (
     <div className="row justify-content-center pt-3 pb-3">
       <div className="col-sm-12 col-md-9 col-lg-7">
@@ -57,5 +38,37 @@ export default function CompoundEntryPage() {
         )}
       </div>
     </div>
+  );
+}
+
+function CompoundEntryWithData() {
+  const { apiRoot } = useConfig();
+  const searchParams = useSearchParams();
+  const compoundName = searchParams.get("compound_name");
+  const [compound, setCompound] = useState<Compound | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!compoundName) return;
+    setError(null);
+    setCompound(null);
+
+    fetch(`${apiRoot}/compound/${encodeURIComponent(compoundName)}`)
+      .then((res) => {
+        if (!res.ok) throw new Error("not found");
+        return res.json();
+      })
+      .then((data) => setCompound(data))
+      .catch((e) => setError(e.message));
+  }, [apiRoot, compoundName]);
+
+  return <CompoundEntry compound={compound} error={error} compoundName={compoundName} />;
+}
+
+export default function CompoundEntryPage() {
+  return (
+    <Suspense fallback={<CompoundEntry compound={null} error={null} />}>
+      <CompoundEntryWithData />
+    </Suspense>
   );
 }

--- a/frontend/bacmet/app/compounds/entry/page.tsx
+++ b/frontend/bacmet/app/compounds/entry/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useConfig } from "../../../contexts/config";
+import { Compound } from "../../search/types";
+
+export default function CompoundEntryPage() {
+  const { apiRoot } = useConfig();
+  const searchParams = useSearchParams();
+  const compoundName = searchParams.get("compound_name");
+  const [compound, setCompound] = useState<Compound | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!compoundName) return;
+    setError(null);
+
+    fetch(`${apiRoot}/compound/${encodeURIComponent(compoundName)}`)
+      .then((res) => {
+        if (!res.ok) throw new Error("not found");
+        return res.json();
+      })
+      .then((data) => setCompound(data))
+      .catch((e) => setError(e.message))
+  }, [apiRoot, compoundName]);
+
+  return (
+    <div className="row justify-content-center pt-3 pb-3">
+      <div className="col-sm-12 col-md-9 col-lg-7">
+        {error && <p className="text-danger text-center">{compoundName} {error}</p>}
+        {compound && (
+          <>
+            <h1 className="text-center">Compound information</h1>
+            <table className="table">
+              <tbody>
+                <tr>
+                  <th scope="row">Name:</th>
+                  <td>{compound.compound_name}</td>
+                </tr>
+                <tr>
+                  <th scope="row">Chemical Class:</th>
+                  <td>{compound.chemical_class}</td>
+                </tr>
+                <tr>
+                  <th scope="row">CAS Number:</th>
+                  <td>{compound.cas_number}</td>
+                </tr>
+                {compound.description && (
+                  <tr>
+                    <th scope="row">Description:</th>
+                    <td>{compound.description}</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/bacmet/app/compounds/page.tsx
+++ b/frontend/bacmet/app/compounds/page.tsx
@@ -63,7 +63,11 @@ function CompoundList({entries}: {entries: Compound[]}) {
             const searchByCompoundUrl = `/search/?${new URLSearchParams({compound: entry.compound_name})}`;
             return (
               <tr key={entry.compound_name}>
-                <td scope="col">{entry.compound_name}</td>
+                <td scope="col">
+                  <Link href={`/compounds/entry?${new URLSearchParams({ compound_name: entry.compound_name })}`}>
+                    {entry.compound_name}
+                  </Link>
+                </td>
                 <td scope="col">{entry.chemical_class}</td>
                 <td scope="col">{entry.cas_number}</td>
                 <td scope="col">

--- a/frontend/bacmet/app/search/types.ts
+++ b/frontend/bacmet/app/search/types.ts
@@ -26,6 +26,7 @@ export type Compound = {
   compound_name: string;
   chemical_class: string;
   cas_number: string;
+  description?: string;
 }
 
 export type Validated = {


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes https://github.com/NBISweden/bacmet/issues/109

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## List of changes made
- Create function and endpoint for getting information for a single compound. 
- Create view page for displaying information for a compound. 
- Add a link for the compound name in the compounds list (in `/compounds`) that links to the new view page.
- Update typing for compound (both in backend and frontend)  

## Screenshot of the fix
<img width="2514" height="1836" alt="image" src="https://github.com/user-attachments/assets/0b85d8f8-6ae7-48cb-aff6-79d19ec75201" />

<img width="1610" height="1002" alt="image" src="https://github.com/user-attachments/assets/b934fd10-ddd4-404c-a6c4-b9c02193f78f" />

## Testing
1. Go to `/compounds` and view the list of compounds. 
2. Click on a compound name in the list. 
3. Make sure you're redirected to a new page with `name`, `cas number`, `chemical class` and `description`. Note! Some compounds, like metals, does not have description and it will therefore not be rendered. 
4. Go back to the list of compounds and click on the two first compounds in the list `1a-62/JC-1-127 [class: Guanylhydrazones]` and `1i-39/JC-1-134 [class: Guanylhydrazones]` an see that it works as it should. 

## Further comments
The two first compounds in the list contains `/` and that messed up the url and that's why `path:` was added to the endpoint `/api/compound/<path:compound_name>`

Mattias helped a lot with this! :pray: 

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any