### PR TITLE
Fix regression in filtering of predicted entries

### DIFF
--- a/app/app/search.py
+++ b/app/app/search.py
@@ -279,7 +279,6 @@ def apply_search_filters(
     total_filter = reduce(operator.and_, filters, sql.true())
     return (
         stmt.filter(total_filter)
-        .group_by(Validated.validated_id)
         .order_by(total_rank.desc())
     )
 
@@ -354,7 +353,7 @@ def find_in_validated(
         peptide_sequence_length_range,
         gene_name,
         free_text
-    )
+    ).group_by(Validated.validated_id)
     with db_session() as session:
         items = session.execute(
             apply_pagination(stmt, pagination)


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->
## Related issue(s) and PR(s)

This PR will fix a regression in the filtering of predicted entries caused by changes to the shared filters function when implementing the ranking of search results. The issue revealed itself by all queries to the predicted api endpoint only returning a single entry.

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change

<!-- Please delete options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

## List of changes made

- Move `group_by` from shared filter function to the function responsible for validated results

## Testing

- go to: http://localhost:5000/search/entry/?entry_id=BAC0031
- verify that you get more than one predicted entry

## Further comments

<!-- Specify questions or related information -->

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any