### PR TITLE
Feat: display CAS-number in search entry

### DIFF
--- a/frontend/bacmet/app/search/components/validated-entry.tsx
+++ b/frontend/bacmet/app/search/components/validated-entry.tsx
@@ -15,10 +15,15 @@ export default function ValidatedEntry({entry}: {entry: Validated | ReplicateKey
         <tr><th scope="row">Organism:</th><td><em>{ entry.organism }</em></td></tr>
         <tr><th scope="row">Location:</th><td>{ entry.location }</td></tr>
         <tr><th scope="row">Compound:</th><td>{Array.isArray(entry.compounds) ? <>
-          {entry.compounds.map((c, index, array) => <React.Fragment key={c.compound_name}>
-            <Link href={`/compounds/entry?${new URLSearchParams({ compound_name: c.compound_name })}`}>{c.compound_name}</Link>
-            {index < array.length -1 ? ", " : <></>}
-          </React.Fragment>)}
+          {entry.compounds.map((c, index, array) => (
+            <React.Fragment key={c.compound_name}>
+              <Link href={`/compounds/entry?${new URLSearchParams({ compound_name: c.compound_name })}`}>
+                {c.compound_name}
+                {c.cas_number ? ` [${c.cas_number}]` : ""}
+              </Link>
+              {index < array.length -1 ? ", " : <></>}
+            </React.Fragment>
+          ))}
         </> : entry.compounds}</td></tr>
         <tr><th scope="row">Description:</th><td>{ entry.description }</td></tr>
         <tr><th scope="row">Length (amino acid):</th><td>{ entry.length_aa }</td></tr>


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes https://github.com/NBISweden/bacmet/issues/123

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## List of changes made
- Display `CAS-number` in search entry on `Search`-page. 

## Screenshot of the fix
<img width="1856" height="982" alt="image" src="https://github.com/user-attachments/assets/61b9770a-8ba0-4b34-8f3a-47e56343ef04" />

## Testing
Go to `/search` and perform a search. See that the `CAS-number` is displayed next to the compound name. 

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any