### PR TITLE
fix: include CAS numbers in compound labels to make them filterable

### DIFF
--- a/frontend/bacmet/app/search/page.tsx
+++ b/frontend/bacmet/app/search/page.tsx
@@ -74,7 +74,7 @@ const SearchBase = (
         chemicalClasses: ccs.items,
         compounds: cs.items.map(c => ({
           value: c.compound_name,
-          label: c.compound_name,
+          label: c.cas_number ? `${c.compound_name} [${c.cas_number}]` : c.compound_name,
           _meta: {chemical_class: c.chemical_class}
         })),
         geneNames: gns.items


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->
## Related issue(s) and PR(s)

This PR closes #122

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change

<!-- Please delete options that are not relevant -->

- [x] New feature (non-breaking change which adds functionality)

## List of changes made

- Include CAS-numbers in compound labels for compound filter options

## Screenshot of the fix

<img width="2576" height="1154" alt="Screen Shot 2025-10-07 at 14 52 45" src="https://github.com/user-attachments/assets/137de2b8-ef61-4e68-a7c0-f76f539491a4" />

<img width="2576" height="1154" alt="Screen Shot 2025-10-07 at 15 38 56" src="https://github.com/user-attachments/assets/b10e79cd-b2a7-4a6d-b41c-0b4510ba06a2" />

## Testing

- go to: http://localhost:5000/search/
- view the compound filters
- start typing a CAS number
- expect compounds to be properly filtered

## Further comments

<!-- Specify questions or related information -->

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any