### PR TITLE
Filter compounds by cas number

### DIFF
--- a/frontend/bacmet/app/compounds/page.tsx
+++ b/frontend/bacmet/app/compounds/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { useConfig } from "../../contexts/config";
-import { Suspense, useCallback, useState, useEffect, FormEventHandler, useMemo } from "react";
+import { Suspense, useCallback, useState, useMemo } from "react";
 import { Compound, Result, Field } from "../search/types";
 import { usePromiseData, fetchData } from "../utils";
 import { TextField } from "../search/components/text-field";
@@ -23,32 +23,25 @@ function CompoundListWithData() {
 }
 
 function CompoundList({entries, children}: {entries: Compound[], children?: React.ReactNode}) {
-  const [filteredEntries, setFilteredEntries] = useState(entries);
+  const [filterText, setFilterText] = useState<string>("");
 
-  const searchField: Field<string> = useMemo(() => ({
-    label: "Filter by compound name, chemical class, or CAS number",
-    name: "compound_filtering",
-    value: "",
-    values: [],
-    placeholder: "compound name, chemical class, or CAS number"
-  }), []);
-
-  useEffect(() => {
-    setFilteredEntries(entries);
-  }, [entries]);
-
-  const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback((event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    const text = event.currentTarget["compound_filtering"]?.value?.trim().toLowerCase() || "";
-    setFilteredEntries(entries.filter(c =>
+  const filteredEntries = useMemo(() => {
+    const text = filterText.trim().toLowerCase();
+    return entries.filter(c =>
       !text ||
       c.compound_name.toLowerCase().includes(text) ||
       c.chemical_class.toLowerCase().includes(text) ||
       (c.cas_number && c.cas_number.toLowerCase().includes(text))
-    )
     );
-  }, [entries]);
+  }, [entries, filterText]);
+
+  const filterField: Field<string> = useMemo(() => ({
+    label: "Filter by compound name, chemical class, or CAS number",
+    name: "compound_filtering",
+    value: filterText,
+    values: [],
+    placeholder: "compound name, chemical class, or CAS number"
+  }), [filterText]);
 
   return (
     <div className="col-sm-12 col-md-9 col-lg-7">
@@ -56,12 +49,7 @@ function CompoundList({entries, children}: {entries: Compound[], children?: Reac
       {children}
       {entries.length > 0 ? (
         <>
-          <form onSubmit={handleSubmit}>
-            <TextField field={searchField} />
-            <div className="pt-3 pb-2">
-              <input className="btn btn-primary" type="submit" value="Filter" />
-            </div>
-          </form>
+          <TextField field={filterField} onChange={event => setFilterText(event.target.value)}/>
           <hr />
           <table className="table">
             <thead>

--- a/frontend/bacmet/app/compounds/page.tsx
+++ b/frontend/bacmet/app/compounds/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { useConfig } from "../../contexts/config";
-import { Suspense, useCallback, useState, useEffect, FormEventHandler } from "react";
+import { Suspense, useCallback, useState, useEffect, FormEventHandler, useMemo } from "react";
 import { Compound, Result, Field } from "../search/types";
 import { usePromiseData, fetchData } from "../utils";
 import { TextField } from "../search/components/text-field";
@@ -25,13 +25,13 @@ function CompoundListWithData() {
 function CompoundList({entries, children}: {entries: Compound[], children?: React.ReactNode}) {
   const [filteredEntries, setFilteredEntries] = useState(entries);
 
-  const searchField: Field<string> = {
+  const searchField: Field<string> = useMemo(() => ({
     label: "Filter by compound name, chemical class, or CAS number",
     name: "compound_filtering",
     value: "",
     values: [],
     placeholder: "compound name, chemical class, or CAS number"
-  };
+  }), []);
 
   useEffect(() => {
     setFilteredEntries(entries);

--- a/frontend/bacmet/app/compounds/page.tsx
+++ b/frontend/bacmet/app/compounds/page.tsx
@@ -1,9 +1,9 @@
 "use client"
 import { useConfig } from "../../contexts/config";
-import { Suspense, useCallback, useState, useMemo } from "react";
-import { Compound, Result, MultiValueField, FieldValue } from "../search/types";
+import { Suspense, useCallback, useState, useEffect, FormEventHandler } from "react";
+import { Compound, Result, Field } from "../search/types";
 import { usePromiseData, fetchData } from "../utils";
-import { MultiSelectField } from "../search/components/multi-select-field/multi-select-field";
+import { TextField } from "../search/components/text-field";
 import Link from 'next/link'
 import ErrorView from "../components/error-view";
 import { LineLoading } from "../components/loading/loading";
@@ -34,27 +34,46 @@ function CompoundListWithData() {
 }
 
 function CompoundList({entries, children}: {entries: Compound[], children?: React.ReactNode}) {
-  const [usedChemcialClasses, setUsedChemicalClasses] = useState<Set<unknown>>(new Set());
-  const chemicalClasses = useMemo(() => (
-    Array.from(new Set<string>(entries.map(c => c.chemical_class)))
-    .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
-    .map<FieldValue>(cc => ({value: cc, label: cc}))
-  ), [entries]);
-  const chemicalClassField: MultiValueField = useMemo(() => ({
-    label: "Filter by chemical classes",
-    name: "chemical_class",
-    value: Array.from(usedChemcialClasses || []),
-    values: chemicalClasses,
-  }), [usedChemcialClasses, chemicalClasses]);
-  const handleSelectedChemicalClass = useCallback((value: unknown[]) => setUsedChemicalClasses(new Set(value)), [setUsedChemicalClasses])
-  const filteredEntries = entries.filter(c => usedChemcialClasses.size > 0 ? usedChemcialClasses.has(c.chemical_class) : true );
+  const [filteredEntries, setFilteredEntries] = useState(entries);
+
+  const searchField: Field<string> = {
+    label: "Filter by compound name, chemical class, or CAS number",
+    name: "compound_filtering",
+    value: "",
+    values: [],
+    placeholder: "compound name, chemical class, or CAS number"
+  };
+
+  useEffect(() => {
+    setFilteredEntries(entries);
+  }, [entries]);
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback((event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const text = event.currentTarget["compound_filtering"]?.value?.trim().toLowerCase() || "";
+    setFilteredEntries(
+      entries.filter(c =>
+        !text ||
+        c.compound_name.toLowerCase().includes(text) ||
+        c.chemical_class.toLowerCase().includes(text) ||
+        (c.cas_number && c.cas_number.toLowerCase().includes(text))
+      )
+    );
+  }, [entries]);
+
   return (
     <div className="col-sm-12 col-md-9 col-lg-7">
       <h1 className="text-center">Compounds</h1>
       {children}
       {entries.length > 0 ? (
         <>
-          <MultiSelectField field={chemicalClassField} onChange={handleSelectedChemicalClass}/>
+          <form onSubmit={handleSubmit}>
+            <TextField field={searchField} />
+            <div className="pt-3 pb-2">
+              <input className="btn btn-primary" type="submit" value="Filter" />
+            </div>
+          </form>
           <hr />
           <table className="table">
             <thead>

--- a/frontend/bacmet/app/compounds/page.tsx
+++ b/frontend/bacmet/app/compounds/page.tsx
@@ -8,17 +8,6 @@ import Link from 'next/link'
 import ErrorView from "../components/error-view";
 import { LineLoading } from "../components/loading/loading";
 
-const DefaultCompounds: Result<Compound> = {
-  items: [],
-  _meta: {
-    totalRecords: 0,
-    totalPages: 0,
-    page: 0,
-    count: 0,
-  },
-  _links: [],
-}
-
 function CompoundListWithData() {
   const {apiRoot} = useConfig();
 
@@ -52,13 +41,12 @@ function CompoundList({entries, children}: {entries: Compound[], children?: Reac
     event.preventDefault();
     event.stopPropagation();
     const text = event.currentTarget["compound_filtering"]?.value?.trim().toLowerCase() || "";
-    setFilteredEntries(
-      entries.filter(c =>
-        !text ||
-        c.compound_name.toLowerCase().includes(text) ||
-        c.chemical_class.toLowerCase().includes(text) ||
-        (c.cas_number && c.cas_number.toLowerCase().includes(text))
-      )
+    setFilteredEntries(entries.filter(c =>
+      !text ||
+      c.compound_name.toLowerCase().includes(text) ||
+      c.chemical_class.toLowerCase().includes(text) ||
+      (c.cas_number && c.cas_number.toLowerCase().includes(text))
+    )
     );
   }, [entries]);
 

--- a/frontend/bacmet/app/search/components/text-field.tsx
+++ b/frontend/bacmet/app/search/components/text-field.tsx
@@ -1,7 +1,7 @@
 import {useId} from "react";
 import {Field} from "../types";
 
-export const TextField = ({field}: {field: Field<unknown>}) => {
+export const TextField = ({field, onChange}: {field: Field<unknown>, onChange?: React.ChangeEventHandler<HTMLInputElement>}) => {
   const fieldId = useId();
   return (
     <>
@@ -13,6 +13,7 @@ export const TextField = ({field}: {field: Field<unknown>}) => {
         defaultValue={field.value !== undefined ? field.value + "" : undefined}
         id={fieldId}
         placeholder={field.placeholder}
+        onChange={onChange}
       />
     </>
   )


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes https://github.com/NBISweden/bacmet/issues/124.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## List of changes made
- Created a text field where the user can filter the compound list by compound name, chemical class and cas-number. 
- Removed the section with checkboxes for filtering by chemical class
- Removed unused variable called `DefaultCompounds`. 

## Screenshot of the fix
<img width="1928" height="1110" alt="image" src="https://github.com/user-attachments/assets/0663444f-3dd9-4ba1-866d-54be6cab1549" />

<img width="1928" height="1110" alt="image" src="https://github.com/user-attachments/assets/8584dc6f-6bd8-4c5e-bdd4-20d396b03231" />

## Testing
Check out this branch and filter the compounds by compound name, chemical class and cas-number. Check that the result is what you would expect. 

## Further comments
This text field does not work the same way as the `free text`-search in the `Search`-page. 

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any